### PR TITLE
fix: use new &tab= URL format

### DIFF
--- a/src/url.ts
+++ b/src/url.ts
@@ -135,7 +135,7 @@ export function escapeRevspecForURL(rev: string): string {
 }
 
 export function toViewStateHashComponent(viewState: string | undefined): string {
-    return viewState ? `$${viewState}` : ''
+    return viewState ? `&tab=${viewState}` : ''
 }
 
 export function toPrettyBlobURL(


### PR DESCRIPTION
Since https://github.com/sourcegraph/sourcegraph/pull/12109, URLs with a view state (eg `references`) have used `#L123&tab=references` not `#L123$references`.

This commit fixes the URLs for the hover actions, which eliminates a `<Redirect>` (which, in turn, causes a full unmount-mount cycle for `BlobPage` and all of its children, which is slow).