### PR TITLE
feat(hoverifier): support diff views without diff indicators

### DIFF
--- a/src/positions.ts
+++ b/src/positions.ts
@@ -67,10 +67,7 @@ export const findPositionsFromEvents = (options: DOMFunctions) => (
     ).pipe(
         // Find out the position that was hovered over
         map(({ target, codeView, ...rest }) => {
-            const hoveredToken = locateTarget(target, {
-                ignoreFirstChar: !!options.getDiffCodePart,
-                ...options,
-            })
+            const hoveredToken = locateTarget(target, options)
             const position = Position.is(hoveredToken) ? hoveredToken : undefined
             return { position, codeView, ...rest }
         })


### PR DESCRIPTION
Adds `isFirstCharacterDiffIndicator` to `DOMFunctions` to determine whether the first character in the code element is the diff indicator