### PR TITLE
fix: pass correct value to HoverMerged.is

### DIFF
--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -428,7 +428,7 @@ export const createHoverifier = ({
             .pipe(
                 distinctUntilChanged(([positionA], [positionB]) => isEqual(positionA, positionB)),
                 switchMap(([position, hoverObservable]) => hoverObservable),
-                filter(HoverMerged.is)
+                filter(({ hoverOrError }) => HoverMerged.is(hoverOrError))
             )
             .subscribe(() => {
                 logTelemetryEvent('SymbolHovered')


### PR DESCRIPTION
Before, the object containing `hoverOrError` was being passed, not just `hoverOrError`.