### PR TITLE
feat: hold down ctrl/meta to go-to-def on clicks

### DIFF
--- a/src/hoverifier.test.ts
+++ b/src/hoverifier.test.ts
@@ -139,7 +139,7 @@ describe('Hoverifier', () => {
 
                 const hoverifier = createHoverifier({
                     closeButtonClicks: new Observable<MouseEvent>(),
-                    goToDefinitionClicks: new Observable<MouseEvent>(),
+                    goToDefinitionClicks: new Subject<MouseEvent>(),
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     fetchHover,

--- a/src/hoverifier.test.ts
+++ b/src/hoverifier.test.ts
@@ -40,7 +40,7 @@ describe('Hoverifier', () => {
             scheduler.run(({ cold, expectObservable }) => {
                 const hoverifier = createHoverifier({
                     closeButtonClicks: new Observable<MouseEvent>(),
-                    goToDefinitionClicks: new Observable<MouseEvent>(),
+                    goToDefinitionClicks: new Subject<MouseEvent>(),
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     fetchHover: createStubHoverFetcher(hover, delayTime),

--- a/src/positions.ts
+++ b/src/positions.ts
@@ -1,19 +1,19 @@
-import { fromEvent, merge, Observable } from 'rxjs'
+import { fromEvent, merge, Observable, pipe } from 'rxjs'
 import { filter, map, switchMap, tap } from 'rxjs/operators'
 import { Position } from 'vscode-languageserver-types'
 import { convertCodeElementIdempotent, DiffPart, DOMFunctions, HoveredToken, locateTarget } from './token_position'
 
-export type SupportedMouseEvent = 'click' | 'mousemove' | 'mouseover'
+export type SupportedEvent = 'click' | 'mousemove' | 'mouseover' | 'keydown' | 'keyup'
 
 export interface PositionEvent {
     /**
      * The event object
      */
-    event: MouseEvent
+    event: MouseEvent | KeyboardEvent
     /**
-     * The type of mouse event that caused this to emit.
+     * The type of event that caused this to emit.
      */
-    eventType: SupportedMouseEvent
+    eventType: SupportedEvent
     /**
      * The position of the token that the event occured at.
      * or undefined when a target was hovered/clicked that does not correspond to a position (e.g. after the end of the line)
@@ -25,6 +25,24 @@ export interface PositionEvent {
     codeView: HTMLElement
 }
 
+/**
+ * The current target element and code view being hovered over.
+ * Used to select the relevant target on KeyboardEvents (which a user will want to apply to the hovered token, but
+ * which actually register on another, unrelated element that has focus).
+ */
+let hoverTarget: HTMLElement | undefined
+let hoverCodeView: HTMLElement | undefined
+
+const findPositionsForKeyboardEvents = pipe(
+    filter((event: { event: KeyboardEvent; eventType: SupportedEvent }) => event.event.currentTarget !== null),
+    map(({ event, ...rest }) => ({
+        event,
+        target: hoverTarget as HTMLElement,
+        codeView: hoverCodeView as HTMLElement,
+        ...rest,
+    }))
+)
+
 export { DOMFunctions, DiffPart }
 export const findPositionsFromEvents = (options: DOMFunctions) => (
     elements: Observable<HTMLElement>
@@ -34,6 +52,10 @@ export const findPositionsFromEvents = (options: DOMFunctions) => (
             switchMap(element => fromEvent<MouseEvent>(element, 'mouseover')),
             map(event => ({ event, eventType: 'mouseover' as 'mouseover' })),
             filter(({ event }) => event.currentTarget !== null),
+            tap(event => {
+                hoverTarget = event.event.target as HTMLElement
+                hoverCodeView = event.event.currentTarget as HTMLElement
+            }),
             map(({ event, ...rest }) => ({
                 event,
                 target: event.target as HTMLElement,
@@ -63,6 +85,16 @@ export const findPositionsFromEvents = (options: DOMFunctions) => (
                 codeView: event.currentTarget as HTMLElement,
                 ...rest,
             }))
+        ),
+        elements.pipe(
+            switchMap(() => fromEvent<KeyboardEvent>(window, 'keydown')),
+            map(event => ({ event, eventType: 'keydown' as 'keydown' })),
+            findPositionsForKeyboardEvents
+        ),
+        elements.pipe(
+            switchMap(() => fromEvent<KeyboardEvent>(window, 'keyup')),
+            map(event => ({ event, eventType: 'keyup' as 'keyup' })),
+            findPositionsForKeyboardEvents
         )
     ).pipe(
         // Find out the position that was hovered over


### PR DESCRIPTION
Video of how this works in dev: https://cl.ly/2k1n470y083b

My remaining concerns:

- [ ] The action of pressing cmd/ctrl now causes any currently displayed hover to disappear (but you can move off of the symbol, and then back on to bring it back). This can probably be cleaned up.

- [ ] My additions to position.ts seem a bit dangerous (adding global `hoverTarget` and `hoverCodeView` vars, in particular). Any thoughts on how to improve this? https://github.com/sourcegraph/codeintellify/compare/cmdj2d?expand=1#diff-baad18ed00346ed65d8f93a0f6579b20R33

- [ ] Get @francisschmaltz's eyes on styling (see  https://github.com/sourcegraph/sourcegraph/pull/12850)