### PR TITLE
fix: Highlight only when response

### DIFF
--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -557,7 +557,7 @@ export const createHoverifier = ({
                 if (currentHighlighted) {
                     currentHighlighted.classList.remove('selection-highlight')
                 }
-                if (!position) {
+                if (!position || !hoverOrError) {
                     return
                 }
 


### PR DESCRIPTION
Before https://github.com/sourcegraph/codeintellify/pull/45, we didn't highlight the hovered token until we got a hover response. Otherwise we'd highlight _every single_ token including whitespace and comments even if there's no hover information. This PR fixes that regression while keeping the improvements from #45 .