### PR TITLE
fix: handle invalid hover responses by displaying errors

### DIFF
--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -485,6 +485,16 @@ export const createHoverifier = ({
             }
             // Fetch the hover for that position
             const hoverFetch = fetchHover(position).pipe(
+                // Some language servers don't conform to the LSP specification
+                // (e.g. Python LS sometimes returns an empty object). For the
+                // convenience of consumers of codeintellify, we'll handle this
+                // here.
+                map(
+                    hoverMergedOrNull =>
+                        hoverMergedOrNull === null || HoverMerged.is(hoverMergedOrNull)
+                            ? hoverMergedOrNull
+                            : new Error(`Invalid hover response: ${JSON.stringify(hoverMergedOrNull)}`)
+                ),
                 catchError(error => {
                     if (error && error.code === EMODENOTFOUND) {
                         return [null]


### PR DESCRIPTION
Sometimes language servers return invalid hover information. Currently, codeintellify just sort of gets angry and quits working after this happens. @chrismwendt and I discussed a few different options for handling this and we decided that while the solution this PR has is the ideal solution<sup>1</sup>, it is more convenient for consumers of codeintellify. 

<sup>1</sup> The ideal solution would be that each language server perfectly adheres to the specification or at least _each_ codeintellify consumer handles the errors on it's own.