### PR TITLE
Accept Subscribable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7541,9 +7541,9 @@
       }
     },
     "rxjs": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.1.tgz",
-      "integrity": "sha512-OwMxHxmnmHTUpgO+V7dZChf3Tixf4ih95cmXjzzadULziVl/FKhHScGLj4goEw9weePVOH2Q0+GcCBUhKCZc/g==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.0.tgz",
+      "integrity": "sha512-ZnwuEquf72mnVORgX75eZCAKNNwulmKQuFxDPwDA5EvbkBXeRNJtmvhyVLcPcKkdiUtqqv+LbBM8jYo0eBW++w==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -8697,9 +8697,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
+      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
       "dev": true
     },
     "ua-parser-js": {

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -472,16 +472,21 @@ export const createHoverifier = ({
      * For every position, emits an Observable with new values for the `hoverOrError` state.
      * This is a higher-order Observable (Observable that emits Observables).
      */
-    const hoverObservables = resolvedPositions.pipe(
+    const hoverObservables: Observable<
+        Observable<{
+            eventType: SupportedMouseEvent | 'jump'
+            dom: DOMFunctions
+            target: HTMLElement
+            adjustPosition?: PositionAdjuster
+            codeView: HTMLElement
+            hoverOrError?: typeof LOADING | HoverMerged | Error | null
+            position?: HoveredToken & HoveredTokenContext
+            part?: DiffPart
+        }>
+    > = resolvedPositions.pipe(
         map(({ position, ...rest }) => {
             if (!position) {
-                return of({
-                    // Typescript seems to give up on type inference if we don't explicitely declare the types here.
-                    hoverOrError: null as 'loading' | HoverMerged | Error | null | undefined,
-                    position: undefined as (HoveredToken & HoveredTokenContext) | undefined,
-                    part: undefined,
-                    ...rest,
-                })
+                return of({ hoverOrError: null, position: undefined, part: undefined, ...rest })
             }
             // Fetch the hover for that position
             const hoverFetch = fetchHover(position).pipe(

--- a/src/positions.ts
+++ b/src/positions.ts
@@ -1,4 +1,4 @@
-import { fromEvent, merge, Observable } from 'rxjs'
+import { from, fromEvent, merge, Observable, Subscribable } from 'rxjs'
 import { filter, map, switchMap, tap } from 'rxjs/operators'
 import { Position } from 'vscode-languageserver-types'
 import { convertCodeElementIdempotent, DiffPart, DOMFunctions, HoveredToken, locateTarget } from './token_position'
@@ -27,10 +27,10 @@ export interface PositionEvent {
 
 export { DOMFunctions, DiffPart }
 export const findPositionsFromEvents = (options: DOMFunctions) => (
-    elements: Observable<HTMLElement>
+    elements: Subscribable<HTMLElement>
 ): Observable<PositionEvent> =>
     merge(
-        elements.pipe(
+        from(elements).pipe(
             switchMap(element => fromEvent<MouseEvent>(element, 'mouseover')),
             map(event => ({ event, eventType: 'mouseover' as 'mouseover' })),
             filter(({ event }) => event.currentTarget !== null),
@@ -50,7 +50,7 @@ export const findPositionsFromEvents = (options: DOMFunctions) => (
                 }
             })
         ),
-        elements.pipe(
+        from(elements).pipe(
             switchMap(element => fromEvent<MouseEvent>(element, 'click')),
             map(event => ({ event, eventType: 'click' as 'click' })),
             // ignore click events caused by the user selecting text.


### PR DESCRIPTION
Updates to RxJS 6.3, which includes my PR that fixes the `Subscribable` signature.
We can replace all required _inputs_ that were `Observable` before with `Subscribable` (and convert them with `from()`) so that we depend on interfaces instead of classes. Interfaces are duck-typed, so `npm link`ed versions don't cause conflicts if the interfaces are compatible.

All callback types can now return `SubscribableOrPromise` to make clear that they should only return one result. Eventually I would like to switch them to return only `Promise` and pass an `AbortSignal` (but it would be a breaking change).