### PR TITLE
fix: don't highlight on empty hover responses

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -21,7 +21,7 @@ export const propertyIsDefined = <T extends object, K extends keyof T>(key: K) =
 ): val is K extends any ? ({ [k in Exclude<keyof T, K>]: T[k] } & { [k in K]: NonNullable<T[k]> }) : never =>
     isDefined(val[key])
 
-const isEmptyHover = (hover: HoverMerged | null): boolean =>
+export const isEmptyHover = (hover: HoverMerged | null): boolean =>
     !hover ||
     !hover.contents ||
     (Array.isArray(hover.contents) && hover.contents.length === 0) ||

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -30,7 +30,7 @@ import { Key } from 'ts-key-enum'
 import { Position } from 'vscode-languageserver-types'
 import { asError, ErrorLike } from './errors'
 import { isDefined } from './helpers'
-import { overlayUIHasContent, scrollIntoCenterIfNeeded } from './helpers'
+import { isEmptyHover, overlayUIHasContent, scrollIntoCenterIfNeeded } from './helpers'
 import { HoverOverlayProps, isJumpURL } from './HoverOverlay'
 import { calculateOverlayPosition } from './overlay_position'
 import { DiffPart, PositionEvent, SupportedMouseEvent } from './positions'
@@ -594,7 +594,7 @@ export const createHoverifier = ({
                 if (currentHighlighted) {
                     currentHighlighted.classList.remove('selection-highlight')
                 }
-                if (!position || !hoverOrError) {
+                if (!position || !hoverOrError || (HoverMerged.is(hoverOrError) && isEmptyHover(hoverOrError))) {
                     return
                 }
 


### PR DESCRIPTION
Sending `null` and `{content: []}` are both valid responses from language servers for empty hover responses. Before this PR, if we got `{content: []}`, we highlight the token because it is a valid hover, however, this is not the intended experience.

Fixes https://github.com/sourcegraph/sourcegraph/issues/13180