### PR TITLE
feat: align hoverOverlay with right of target when it exceeds viewport

### DIFF
--- a/src/overlay_position.test.ts
+++ b/src/overlay_position.test.ts
@@ -83,6 +83,13 @@ describe('overlay_position', () => {
                     applyOffsets(hoverOverlayElement, position)
                     assert.deepStrictEqual(position, { left: 100, top: 116 })
                 })
+
+                it('should return a position aligned with the right of the target', () => {
+                    const target = createTarget({ left: 700, top: 200 })
+                    const position = calculateOverlayPosition({ relativeElement, target, hoverOverlayElement })
+                    applyOffsets(hoverOverlayElement, position)
+                    assert.deepStrictEqual(position, { left: 410, top: 50 })
+                })
             })
             describe('scrolled', () => {
                 beforeEach(() => {
@@ -102,6 +109,13 @@ describe('overlay_position', () => {
                     const position = calculateOverlayPosition({ relativeElement, target, hoverOverlayElement })
                     applyOffsets(hoverOverlayElement, position)
                     assert.deepStrictEqual(position, { left: 100, top: 466 })
+                })
+
+                it('should return a position aligned with the right of the target', () => {
+                    const target = createTarget({ left: 700, top: 450 })
+                    const position = calculateOverlayPosition({ relativeElement, target, hoverOverlayElement })
+                    applyOffsets(hoverOverlayElement, position)
+                    assert.deepStrictEqual(position, { left: 410, top: 466 })
                 })
             })
         })
@@ -132,6 +146,13 @@ describe('overlay_position', () => {
                     applyOffsets(hoverOverlayElement, position)
                     assert.deepStrictEqual(position, { left: 100, top: 156 })
                 })
+
+                it('should return a position aligned with the right of the target', () => {
+                    const target = createTarget({ left: 700, top: 200 })
+                    const position = calculateOverlayPosition({ relativeElement, target, hoverOverlayElement })
+                    applyOffsets(hoverOverlayElement, position)
+                    assert.deepStrictEqual(position, { left: 410, top: 50 })
+                })
             })
             describe('scrolled', () => {
                 beforeEach(() => {
@@ -156,6 +177,13 @@ describe('overlay_position', () => {
                     const position = calculateOverlayPosition({ relativeElement, target, hoverOverlayElement })
                     applyOffsets(hoverOverlayElement, position)
                     assert.deepStrictEqual(position, { left: 300, top: 466 })
+                })
+
+                it('should return a position aligned with the right of the target', () => {
+                    const target = createTarget({ left: 900, top: 450 })
+                    const position = calculateOverlayPosition({ relativeElement, target, hoverOverlayElement })
+                    applyOffsets(hoverOverlayElement, position)
+                    assert.deepStrictEqual(position, { left: 610, top: 466 })
                 })
             })
         })

--- a/src/overlay_position.ts
+++ b/src/overlay_position.ts
@@ -27,8 +27,20 @@ export const calculateOverlayPosition = ({
     const targetBounds = target.getBoundingClientRect()
     const hoverOverlayBounds = hoverOverlayElement.getBoundingClientRect()
 
-    // If the relativeElement is scrolled horizontally, we need to account for the offset (if not scrollLeft will be 0)
-    const relativeHoverOverlayLeft = targetBounds.left + relativeElement.scrollLeft - relativeElementBounds.left
+    let relativeHoverOverlayLeft: number
+
+    // Check if the right of the hover overlay would be outside of the relative element or the viewport
+    if (relativeElementBounds.right < targetBounds.left + hoverOverlayBounds.width) {
+        // Position it to be aligned with the right side of the target
+        // Calculate the offset from the right of the relative element
+        // If the relativeElement is scrolled horizontally, we need to account for the offset (if not scrollLeft will be 0)
+        relativeHoverOverlayLeft =
+            targetBounds.right - relativeElementBounds.left + relativeElement.scrollLeft - hoverOverlayBounds.width
+    } else {
+        // Else position it to be aligned with the left of the target
+        // If the relativeElement is scrolled horizontally, we need to account for the offset (if not scrollLeft will be 0)
+        relativeHoverOverlayLeft = targetBounds.left + relativeElement.scrollLeft - relativeElementBounds.left
+    }
 
     let relativeHoverOverlayTop: number
     // Check if the top of the hover overlay would be outside of the relative element or the viewport


### PR DESCRIPTION
When the hoverOverlay exceeds the right side of the viewport or relative element, the hoverOverlay will now align its right side with the right side of the target so it doesn't overflow.