### PR TITLE
feat: remove Find Implementations button

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Adds code intelligence to code views on the web. Used in [Sourcegraph](https://s
 
 - Listens to hover and click events on the code view
 - On mouse hovers, determines the line+column position, does an LSP hover request and renders it in a nice tooltip overlay at the token
-- Shows buttons for go-to-definition, find-references, find-implementations
+- Shows buttons for go-to-definition and find-references
 - When clicking a token, pins the tooltip to that token
 - Highlights the hovered token
 

--- a/src/HoverOverlay.tsx
+++ b/src/HoverOverlay.tsx
@@ -52,7 +52,7 @@ export interface HoverOverlayProps {
 
     /**
      * The hovered token (position and word).
-     * Used for the Find References/Implementations buttons and for error messages
+     * Used for the Find References buttons and for error messages
      */
     hoveredToken?: HoveredToken & HoveredTokenContext
 
@@ -204,24 +204,6 @@ export const HoverOverlay: React.StatelessComponent<HoverOverlayProps> = ({
                 className="btn btn-secondary hover-overlay__action e2e-tooltip-find-refs"
             >
                 Find references
-            </ButtonOrLink>
-            <ButtonOrLink
-                linkComponent={linkComponent}
-                // tslint:disable-next-line:jsx-no-lambda
-                onClick={() => logTelemetryEvent('FindImplementationsClicked')}
-                to={
-                    hoveredToken &&
-                    toPrettyBlobURL({
-                        repoPath: hoveredToken.repoPath,
-                        rev: hoveredToken.rev,
-                        filePath: hoveredToken.filePath,
-                        position: hoveredToken,
-                        viewState: 'impl',
-                    })
-                }
-                className="btn btn-secondary hover-overlay__action e2e-tooltip-find-impl"
-            >
-                Find implementations
             </ButtonOrLink>
         </div>
         {definitionURLOrError === null ? (

--- a/src/url.ts
+++ b/src/url.ts
@@ -42,7 +42,7 @@ export interface RangeSpec {
     range: Range
 }
 
-export type BlobViewState = 'references' | 'references:external' | 'impl'
+export type BlobViewState = 'references' | 'references:external'
 
 export interface ViewStateSpec {
     /**


### PR DESCRIPTION
It is rarely supported and used, so it does not deserve such prominent billing. A future commit will allow consumers to add this button back.

Helps with https://github.com/sourcegraph/sourcegraph/issues/492