### PR TITLE
fix: listen for mousemove events (previously was not listening)

### DIFF
--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -266,6 +266,9 @@ export const LOADER_DELAY = 1200
 /** The time in ms after the mouse has stopped moving in which to show the tooltip */
 export const TOOLTIP_DISPLAY_DELAY = 100
 
+/** The time in ms to debounce mouseover events. */
+export const MOUSEOVER_DELAY = 50
+
 /**
  * @template C Extra context for the hovered token.
  */
@@ -360,7 +363,7 @@ export function createHoverifier<C extends object>({
             target: event.target as HTMLElement,
             ...rest,
         })),
-        debounceTime(50),
+        debounceTime(MOUSEOVER_DELAY),
         // Do not consider mouseovers while overlay is pinned
         filter(() => !container.values.hoverOverlayIsFixed),
         switchMap(

--- a/src/positions.ts
+++ b/src/positions.ts
@@ -31,8 +31,10 @@ export const findPositionsFromEvents = (options: DOMFunctions) => (
 ): Observable<PositionEvent> =>
     merge(
         from(elements).pipe(
-            switchMap(element => fromEvent<MouseEvent>(element, 'mouseover')),
-            map(event => ({ event, eventType: 'mouseover' as 'mouseover' })),
+            switchMap(element =>
+                merge(fromEvent<MouseEvent>(element, 'mouseover'), fromEvent<MouseEvent>(element, 'mousemove'))
+            ),
+            map(event => ({ event, eventType: event.type as 'mouseover' | 'mousemove' })),
             filter(({ event }) => event.currentTarget !== null),
             map(({ event, ...rest }) => ({
                 event,


### PR DESCRIPTION
Fixes an issue where the TOOLTIP_DISPLAY_DELAY behavior (not showing the tooltip until the mouse had stopped moving for 100msec) was ineffective because no mousemove events were being received. This was because there was no mousemove event listener.

Test plan:

1. Before applying this fix, move your mouse quickly over a token without stopping for 100msec. (You can increase the TOOLTIP_DISPLAY_DELAY constant to make this easier.) Notice that the tooltip appears despite your mouse not ever being stopped for any period of 100msec.
2. Apply this fix. Now try the same. Notice that the tooltip does not appear until your mouse stops moving for 100msec.