### PR TITLE
feat: remove special handling of LSP EMODENOTFOUND

### DIFF
--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -43,7 +43,7 @@ import {
     getTokenAtPosition,
     HoveredToken,
 } from './token_position'
-import { EMODENOTFOUND, HoverMerged, LineOrPositionOrRange, LOADING } from './types'
+import { HoverMerged, LineOrPositionOrRange, LOADING } from './types'
 
 export { HoveredToken }
 
@@ -561,12 +561,7 @@ export function createHoverifier<C extends object>({
                             ? hoverMergedOrNull
                             : new Error(`Invalid hover response: ${JSON.stringify(hoverMergedOrNull)}`)
                 ),
-                catchError(error => {
-                    if (error && error.code === EMODENOTFOUND) {
-                        return [null]
-                    }
-                    return [asError(error)]
-                }),
+                catchError(error => [asError(error)]),
                 share()
             )
             // 1. Reset the hover content, so no old hover content is displayed at the new position while fetching

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,9 +2,6 @@ import { Hover, MarkedString, MarkupContent, Range } from 'vscode-languageserver
 
 export const LOADING: 'loading' = 'loading'
 
-/** LSP proxy error code for unsupported modes */
-export const EMODENOTFOUND = -32000
-
 /** A hover that is merged from multiple Hover results and normalized. */
 export type HoverMerged = Pick<Hover, Exclude<keyof Hover, 'contents'>> & {
     /** Also allows MarkupContent[]. */


### PR DESCRIPTION
These errors should be handled in the observables given to codeintellify, not in codeintellify, now that codeintellify is becoming more about presentation and less about directly interfacing with an LSP lang server.