### PR TITLE
feat: remove telemetry event logging

### DIFF
--- a/src/HoverOverlay.tsx
+++ b/src/HoverOverlay.tsx
@@ -1,5 +1,5 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import { castArray, noop, upperFirst } from 'lodash'
+import { castArray, upperFirst } from 'lodash'
 import AlertCircleOutlineIcon from 'mdi-react/AlertCircleOutlineIcon'
 import CloseIcon from 'mdi-react/CloseIcon'
 import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
@@ -78,8 +78,6 @@ export interface HoverOverlayProps<C = {}> {
 
     /** Called when the close button is clicked */
     onCloseButtonClick?: (event: MouseEvent) => void
-
-    logTelemetryEvent?: (event: string, data?: any) => void
 }
 
 /** Returns true if the input is successful jump URL result */
@@ -100,7 +98,6 @@ export const HoverOverlay: <C>(props: HoverOverlayProps<C>) => React.ReactElemen
     onGoToDefinitionClick,
     overlayPosition,
     showCloseButton,
-    logTelemetryEvent = noop,
     className = '',
 }) => (
     <div
@@ -201,7 +198,6 @@ export const HoverOverlay: <C>(props: HoverOverlayProps<C>) => React.ReactElemen
                     <ButtonOrLink
                         linkComponent={linkComponent}
                         // tslint:disable-next-line:jsx-no-lambda
-                        onClick={() => logTelemetryEvent('FindRefsClicked')}
                         to={referencesURL}
                         className="btn btn-secondary hover-overlay__action e2e-tooltip-find-refs"
                     >

--- a/src/hoverifier.test.ts
+++ b/src/hoverifier.test.ts
@@ -46,7 +46,6 @@ describe('Hoverifier', () => {
                     fetchHover: createStubHoverFetcher(hover, delayTime),
                     fetchJumpURL: createStubJumpURLFetcher(defURL, delayTime),
                     pushHistory: noop,
-                    logTelemetryEvent: noop,
                 })
 
                 const positionJumps = new Subject<{
@@ -148,7 +147,6 @@ describe('Hoverifier', () => {
                     fetchHover,
                     fetchJumpURL,
                     pushHistory: noop,
-                    logTelemetryEvent: noop,
                 })
 
                 const positionJumps = new Subject<{


### PR DESCRIPTION
This is in preparation for removing the hard-coded actions from this library and letting the consumer provide its own actions. This change simplifies the code (slightly) in advance of that.