### PR TITLE
feat: remove close button

### DIFF
--- a/src/HoverOverlay.scss
+++ b/src/HoverOverlay.scss
@@ -11,16 +11,6 @@
 
     transition: opacity 100ms ease-in-out;
 
-    &__close-button {
-        position: absolute;
-        top: 0;
-        right: 0;
-        padding: 0.25rem;
-        background: inherit;
-        z-index: 1;
-        border: none;
-    }
-
     &__row {
         display: block;
         width: 100%;

--- a/src/HoverOverlay.tsx
+++ b/src/HoverOverlay.tsx
@@ -1,7 +1,6 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { castArray, upperFirst } from 'lodash'
 import AlertCircleOutlineIcon from 'mdi-react/AlertCircleOutlineIcon'
-import CloseIcon from 'mdi-react/CloseIcon'
 import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
 import * as React from 'react'
 import { MarkedString, MarkupContent, MarkupKind } from 'vscode-languageserver-types'
@@ -64,9 +63,6 @@ export interface HoverOverlayProps<C = {}> {
      */
     hoveredToken?: HoveredToken & C
 
-    /** Whether to show the close button for the hover overlay */
-    showCloseButton: boolean
-
     /** The component used to render links */
     linkComponent: LinkComponent
 
@@ -75,9 +71,6 @@ export interface HoverOverlayProps<C = {}> {
 
     /** Called when the Go-to-definition button was clicked */
     onGoToDefinitionClick?: (event: MouseEvent) => void
-
-    /** Called when the close button is clicked */
-    onCloseButtonClick?: (event: MouseEvent) => void
 }
 
 /** Returns true if the input is successful jump URL result */
@@ -94,10 +87,8 @@ export const HoverOverlay: <C>(props: HoverOverlayProps<C>) => React.ReactElemen
     hoverOrError,
     hoverRef,
     linkComponent,
-    onCloseButtonClick,
     onGoToDefinitionClick,
     overlayPosition,
-    showCloseButton,
     className = '',
 }) => (
     <div
@@ -118,15 +109,6 @@ export const HoverOverlay: <C>(props: HoverOverlayProps<C>) => React.ReactElemen
                   }
         }
     >
-        {showCloseButton && (
-            <button
-                className="hover-overlay__close-button btn btn-icon"
-                onClick={onCloseButtonClick ? transformMouseEvent(onCloseButtonClick) : undefined}
-            >
-                <CloseIcon className="icon-inline" />
-            </button>
-        )}
-
         {hoverOrError && (
             <div className="hover-overlay__contents">
                 {hoverOrError === LOADING ? (

--- a/src/hoverifier.test.ts
+++ b/src/hoverifier.test.ts
@@ -108,7 +108,6 @@ describe('Hoverifier', () => {
 
             scheduler.run(({ cold, expectObservable }) => {
                 const hoverifier = createHoverifier({
-                    closeButtonClicks: new Observable<MouseEvent>(),
                     goToDefinitionClicks: new Observable<MouseEvent>(),
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
@@ -348,7 +347,6 @@ describe('Hoverifier', () => {
                 }
 
                 const hoverifier = createHoverifier({
-                    closeButtonClicks: new Observable<MouseEvent>(),
                     goToDefinitionClicks: new Observable<MouseEvent>(),
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -71,11 +71,6 @@ export interface HoverifierOptions<C extends object> {
      */
     goToDefinitionClicks: Subscribable<MouseEvent>
 
-    /**
-     * Emit on this Observable when the close button in the HoverOverlay was clicked
-     */
-    closeButtonClicks: Subscribable<MouseEvent>
-
     hoverOverlayElements: Subscribable<HTMLElement | null>
 
     /**
@@ -266,7 +261,6 @@ const internalToExternalState = (internalState: InternalHoverifierState<{}>): Ho
                       : undefined,
               referencesURL: internalState.referencesURL,
               hoveredToken: internalState.hoveredToken,
-              showCloseButton: internalState.hoverOverlayIsFixed,
           }
         : undefined,
 })
@@ -303,7 +297,6 @@ export type ContextResolver<C extends object> = (hoveredToken: HoveredToken) => 
  */
 export function createHoverifier<C extends object>({
     goToDefinitionClicks,
-    closeButtonClicks,
     hoverOverlayRerenders,
     pushHistory,
     fetchHover,
@@ -753,22 +746,21 @@ export function createHoverifier<C extends object>({
         })
     )
 
-    // When the close button is clicked, unpin, hide and reset the hover
+    // When the overlay is closed by user action, unpin, hide and reset the hover
     subscription.add(
-        merge(
-            closeButtonClicks,
-            fromEvent<KeyboardEvent>(window, 'keydown').pipe(filter(event => event.key === Key.Escape))
-        ).subscribe(event => {
-            event.preventDefault()
-            container.update({
-                hoverOverlayIsFixed: false,
-                hoverOverlayPosition: undefined,
-                hoverOrError: undefined,
-                hoveredToken: undefined,
-                definitionURLOrError: undefined,
-                clickedGoToDefinition: false,
-            })
-        })
+        merge(fromEvent<KeyboardEvent>(window, 'keydown').pipe(filter(event => event.key === Key.Escape))).subscribe(
+            event => {
+                event.preventDefault()
+                container.update({
+                    hoverOverlayIsFixed: false,
+                    hoverOverlayPosition: undefined,
+                    hoverOrError: undefined,
+                    hoveredToken: undefined,
+                    definitionURLOrError: undefined,
+                    clickedGoToDefinition: false,
+                })
+            }
+        )
     )
 
     // LOCATION CHANGES


### PR DESCRIPTION
The close button had problems:

- It was a small click target
- It obscured hover content or hover actions in some cases
- It especially looked weird when there were only actions and no hover content; it would obscure part of the rightmost button, not taking up the full width

The problems it solved were:

1. Informing users how to close the overlay
2. Indicating whether the overlay was pinned

For (1), I think users would figure it out that they need to click elsewhere or press the Esc key to close the overlay.

For (2), I don't think it was noticeable enough to effectively do this, and I don't think this is an important goal.