### PR TITLE
Add allowed tags and attributes for extensions

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -105,7 +105,7 @@ export const renderMarkdown = (markdown: string): string => {
         allowedTags: [...sanitize.defaults.allowedTags, 'span', 'h4', 'a', 'p', 'strong', 'details', 'summary'],
         allowedAttributes: {
             span: ['class'],
-            code: ['class'],      
+            code: ['class'],
             a: ['href'],
         },
     })

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -102,7 +102,7 @@ export const renderMarkdown = (markdown: string): string => {
         // Allow highligh.js styles, e.g.
         // <span class="hljs-keyword">
         // <code class="language-javascript">
-        allowedTags: [...sanitize.defaults.allowedTags, 'span', 'h4', 'a', 'p', 'strong', 'details', 'summary'],
+        allowedTags: [...sanitize.defaults.allowedTags, 'span', 'details', 'summary'],
         allowedAttributes: {
             span: ['class'],
             code: ['class'],

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -106,7 +106,7 @@ export const renderMarkdown = (markdown: string): string => {
         allowedAttributes: {
             span: ['class'],
             code: ['class'],      
-            a: ['href']
+            a: ['href'],
         },
     })
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -102,10 +102,11 @@ export const renderMarkdown = (markdown: string): string => {
         // Allow highligh.js styles, e.g.
         // <span class="hljs-keyword">
         // <code class="language-javascript">
-        allowedTags: [...sanitize.defaults.allowedTags, 'span'],
+        allowedTags: [...sanitize.defaults.allowedTags, 'span', 'h4', 'a', 'p', 'strong', 'details', 'summary'],
         allowedAttributes: {
             span: ['class'],
-            code: ['class'],
+            code: ['class'],      
+            a: ['href']
         },
     })
 }


### PR DESCRIPTION
The markdown is passed to [marked](https://marked.js.org/) and then to [sanitize-html](https://www.npmjs.com/package/sanitize-html). In order to get the needed tags, I put my needed markdown into [marked's demo](https://marked.js.org/demo) and looked at the HTML they provided.