### PR TITLE
fix: avoid calling getActions multiple times

### DIFF
--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -691,7 +691,8 @@ export function createHoverifier<C extends object, D, A>({
                 return of(null)
             }
             return concat([LOADING], from(getActions(position)).pipe(catchError(error => [asError(error)])))
-        })
+        }),
+        share()
     )
 
     // ACTIONS


### PR DESCRIPTION
Previously, `getActions()` was being called multiple times (triggering multiple `$observeDefinition`s) for the same position because `actionObservables` is subscribed to twice.

This shares the result of `getActions()` across subscriptions.

Fixes https://github.com/sourcegraph/sourcegraph/issues/1321