### PR TITLE
fix: hide the overlay on hoverify unsubscription

### DIFF
--- a/karma.conf.ts
+++ b/karma.conf.ts
@@ -45,6 +45,11 @@ export default (config: Config): void => {
         mochaReporter: {
             showDiff: true,
         },
+        client: {
+            mocha: {
+                timeout: 6000,
+            },
+        },
         coverageIstanbulReporter: {
             reports: ['json'],
             fixWebpackSourcePaths: true,


### PR DESCRIPTION
Fixes #99 
Fixes https://github.com/sourcegraph/sourcegraph/issues/1064

Proper fix for workaround in https://github.com/sourcegraph/sourcegraph/pull/1171

Ref https://github.com/sourcegraph/sourcegraph/issues/750