### PR TITLE
fix: unsubscribe from actions and hover observable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ You may have to rebase a branch before merging to ensure it has a proper commit 
 
 ## Glossary
 
-| Term                | Definition                                                                                                                                                                                  |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Code view           | The DOM element that contains all the line elements                                                                                                                                         |
-| Line number element | The DOM element that contains the line number label for that line                                                                                                                           |
-| Code element        | The DOM element that contains the code for one line                                                                                                                                         |
-| Diff part           | The part of the diff, either base, head or both (if the line didn't change). Each line belongs to one diff part, and therefor to a different commit ID and potentially different file path. |
-| Hover overlay       | Also called tooltip                                                                                                                                                                         |
+| Term                | Definition                                                                                                                                                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Code view           | The DOM element that contains all the line elements                                                                                                                                                           |
+| Line number element | The DOM element that contains the line number label for that line                                                                                                                                             |
+| Code element        | The DOM element that contains the code for one line                                                                                                                                                           |
+| Diff part           | The part of the diff, either base, head or both (if the line didn't change). Each line belongs to one diff part, and therefor to a different commit ID and potentially different file path.                   |
+| Hover overlay       | Also called tooltip                                                                                                                                                                                           |
+| hoverify            | To attach all the listeners needed to a code view so that it will display overlay on hovers and clicks.                                                                                                       |
+| unhoverify          | To unsubscribe from the Subscription returned by `hoverifier.hoverify()`. Removes all event listeners from the code view again and hides the hover overlay if it was triggered by the unhoverified code view. |

--- a/src/hoverifier.test.ts
+++ b/src/hoverifier.test.ts
@@ -612,8 +612,9 @@ describe('Hoverifier', () => {
                     closeButtonClicks: NEVER,
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
-                    getHover: createStubHoverProvider(),
-                    getActions: () => of(null),
+                    // It's important that getHover() and getActions() emit something
+                    getHover: createStubHoverProvider({}),
+                    getActions: () => of([{}]).pipe(delay(50)),
                 })
                 const positionJumps = new Subject<PositionJump>()
                 const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents(codeView))


### PR DESCRIPTION
Continuation of #100 

The code view was still possible to be re-shown after being hidden because the nested action and hover Observables were not unsubscribed from and could emit after the code view was unhoverified. This would happen on a page navigation, because the removed code view causes the text documents in the extension API to be updated, which causes the Observable returned by `getActions` to emit again.

The test reproduces the problem by making `getActions` emit something.

The fix is to use `takeUntil()` to only take from the actions and hover Observables until the code view is unsubscribed (we need to do this for the two higher-order Observables).

Fixes https://github.com/sourcegraph/sourcegraph/issues/3108