### PR TITLE
Expose the currently hovered token and support disabling pinning

### DIFF
--- a/src/hoverifier.test.ts
+++ b/src/hoverifier.test.ts
@@ -45,6 +45,7 @@ describe('Hoverifier', () => {
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider({ range: hoverRange }, LOADER_DELAY + delayTime),
                     getActions: () => of(null),
+                    pinningEnabled: true,
                 })
 
                 const positionJumps = new Subject<PositionJump>()
@@ -106,6 +107,7 @@ describe('Hoverifier', () => {
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover, delayTime),
                     getActions: createStubActionsProvider(['foo', 'bar'], delayTime),
+                    pinningEnabled: true,
                 })
 
                 const positionJumps = new Subject<PositionJump>()
@@ -199,6 +201,7 @@ describe('Hoverifier', () => {
                             position.line === 24
                                 ? createStubActionsProvider(['foo', 'bar'], delayTime)(position)
                                 : of(null),
+                        pinningEnabled: true,
                     })
 
                     const positionJumps = new Subject<PositionJump>()
@@ -268,6 +271,7 @@ describe('Hoverifier', () => {
                         getHover: position => (position.line === 24 ? createStubHoverProvider({})(position) : of(null)),
                         getActions: position =>
                             position.line === 24 ? createStubActionsProvider(['foo', 'bar'])(position) : of(null),
+                        pinningEnabled: true,
                     })
 
                     const positionJumps = new Subject<PositionJump>()
@@ -346,6 +350,7 @@ describe('Hoverifier', () => {
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover, LOADER_DELAY + hoverDelayTime),
                     getActions: createStubActionsProvider(actions, LOADER_DELAY + actionsDelayTime),
+                    pinningEnabled: true,
                 })
 
                 const positionJumps = new Subject<PositionJump>()
@@ -417,6 +422,7 @@ describe('Hoverifier', () => {
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover),
                     getActions: () => of(null),
+                    pinningEnabled: true,
                 })
 
                 const positionJumps = new Subject<PositionJump>()
@@ -478,6 +484,7 @@ describe('Hoverifier', () => {
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover),
                     getActions: () => of(null),
+                    pinningEnabled: true,
                 })
 
                 const positionJumps = new Subject<PositionJump>()
@@ -560,6 +567,7 @@ describe('Hoverifier', () => {
                     hoverOverlayRerenders: EMPTY,
                     getHover,
                     getActions,
+                    pinningEnabled: true,
                 })
 
                 const positionJumps = new Subject<PositionJump>()
@@ -615,6 +623,7 @@ describe('Hoverifier', () => {
                     // It's important that getHover() and getActions() emit something
                     getHover: createStubHoverProvider({}),
                     getActions: () => of([{}]).pipe(delay(50)),
+                    pinningEnabled: true,
                 })
                 const positionJumps = new Subject<PositionJump>()
                 const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents(codeView))
@@ -655,6 +664,7 @@ describe('Hoverifier', () => {
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(),
                     getActions: () => of(null),
+                    pinningEnabled: true,
                 })
                 const positionJumps = new Subject<PositionJump>()
                 const positionEvents = of(codeViewProps.codeView).pipe(findPositionsFromEvents(codeViewProps))

--- a/src/hoverifier.test.ts
+++ b/src/hoverifier.test.ts
@@ -297,7 +297,7 @@ describe('Hoverifier', () => {
                 )
 
                 const hoverAndDefinitionUpdates = hoverifier.hoverStateUpdates.pipe(
-                    map(hoverState => hoverState.token && hoverState.token.textContent),
+                    map(hoverState => hoverState.hoveredTokenElement && hoverState.hoveredTokenElement.textContent),
                     distinctUntilChanged(isEqual)
                 )
 

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -82,6 +82,11 @@ export interface HoverifierOptions<C extends object, D, A> {
      * Called to get the actions to display in the hover.
      */
     getActions: ActionsProvider<C, A>
+
+    /**
+     * Whether or not hover tooltips can be pinned.
+     */
+    pinningEnabled: boolean
 }
 
 /**
@@ -193,6 +198,16 @@ export interface HoverifyOptions<C extends object>
  */
 export interface HoverState<C extends object, D, A> {
     /**
+     * The hovered and highlighted HTML element.
+     */
+    token?: HTMLElement
+
+    /**
+     * Actions for the current token.
+     */
+    actionsOrError?: typeof LOADING | A[] | null | ErrorLike
+
+    /**
      * The props to pass to `HoverOverlay`, or `undefined` if it should not be rendered.
      */
     hoverOverlayProps?: Pick<HoverOverlayProps<C, D, A>, Exclude<keyof HoverOverlayProps<C, D, A>, 'actionComponent'>>
@@ -216,6 +231,7 @@ export interface HoverState<C extends object, D, A> {
  * @template A The type of an action.
  */
 interface InternalHoverifierState<C extends object, D, A> {
+    token?: HTMLElement
     hoverOrError?: typeof LOADING | (HoverAttachment & D) | null | ErrorLike
 
     hoverOverlayIsFixed: boolean
@@ -274,6 +290,8 @@ const shouldRenderOverlay = (state: InternalHoverifierState<{}, {}, {}>): boolea
 const internalToExternalState = <C extends object, D, A>(
     internalState: InternalHoverifierState<C, D, A>
 ): HoverState<C, D, A> => ({
+    token: internalState.token,
+    actionsOrError: internalState.actionsOrError,
     selectedPosition: internalState.selectedPosition,
     highlightedRange: shouldRenderOverlay(internalState) ? internalState.highlightedRange : undefined,
     hoverOverlayProps: shouldRenderOverlay(internalState)
@@ -328,10 +346,12 @@ export function createHoverifier<C extends object, D, A>({
     hoverOverlayRerenders,
     getHover,
     getActions,
+    pinningEnabled,
 }: HoverifierOptions<C, D, A>): Hoverifier<C, D, A> {
     // Internal state that is not exposed to the caller
     // Shared between all hoverified code views
     const container = createObservableStateContainer<InternalHoverifierState<C, D, A>>({
+        token: undefined,
         hoverOverlayIsFixed: false,
         hoveredToken: undefined,
         hoverOrError: undefined,
@@ -453,31 +473,43 @@ export function createHoverifier<C extends object, D, A>({
     )
 
     /** Emits DOM elements at new positions found in the URL */
-    const jumpTargets = allPositionJumps.pipe(
-        // Only use line and character for comparison
-        map(({ position: { line, character, part }, ...rest }) => ({ position: { line, character, part }, ...rest })),
-        // Ignore same values
-        // It's important to do this before filtering otherwise navigating from
-        // a position, to a line-only position, back to the first position would get ignored
-        distinctUntilChanged((a, b) => isEqual(a, b)),
-        map(({ position, codeView, dom, ...rest }) => {
-            let cell: HTMLElement | null
-            let target: HTMLElement | undefined
-            let part: DiffPart | undefined
-            if (isPosition(position)) {
-                cell = dom.getCodeElementFromLineNumber(codeView, position.line, position.part)
-                if (cell) {
-                    target = findElementWithOffset(cell, position.character)
-                    if (target) {
-                        part = dom.getDiffCodePart && dom.getDiffCodePart(target)
-                    } else {
-                        console.warn('Could not find target for position in file', position)
-                    }
-                }
-            }
-            return { ...rest, eventType: 'jump' as 'jump', target, position: { ...position, part }, codeView, dom }
-        })
-    )
+    const jumpTargets = pinningEnabled
+        ? allPositionJumps.pipe(
+              // Only use line and character for comparison
+              map(({ position: { line, character, part }, ...rest }) => ({
+                  position: { line, character, part },
+                  ...rest,
+              })),
+              // Ignore same values
+              // It's important to do this before filtering otherwise navigating from
+              // a position, to a line-only position, back to the first position would get ignored
+              distinctUntilChanged((a, b) => isEqual(a, b)),
+              map(({ position, codeView, dom, ...rest }) => {
+                  let cell: HTMLElement | null
+                  let target: HTMLElement | undefined
+                  let part: DiffPart | undefined
+                  if (isPosition(position)) {
+                      cell = dom.getCodeElementFromLineNumber(codeView, position.line, position.part)
+                      if (cell) {
+                          target = findElementWithOffset(cell, position.character)
+                          if (target) {
+                              part = dom.getDiffCodePart && dom.getDiffCodePart(target)
+                          } else {
+                              console.warn('Could not find target for position in file', position)
+                          }
+                      }
+                  }
+                  return {
+                      ...rest,
+                      eventType: 'jump' as 'jump',
+                      target,
+                      position: { ...position, part },
+                      codeView,
+                      dom,
+                  }
+              })
+          )
+        : EMPTY
 
     // REPOSITIONING
     // On every componentDidUpdate (after the component was rerendered, e.g. from a hover state update) resposition
@@ -688,9 +720,11 @@ export function createHoverifier<C extends object, D, A>({
                     currentHighlighted.classList.remove('selection-highlight')
                 }
                 if (!highlightedRange) {
+                    container.update({ token: undefined })
                     return
                 }
                 const token = getTokenAtPosition(codeView, highlightedRange.start, dom, part)
+                container.update({ token })
                 if (!token) {
                     return
                 }
@@ -727,40 +761,42 @@ export function createHoverifier<C extends object, D, A>({
             })
     )
 
-    // DEFERRED HOVER OVERLAY PINNING
-    // If the new position came from a click or the URL,
-    // if either the hover or the definition turn out non-empty, pin the tooltip.
-    // If they both turn out empty, unpin it so we don't end up with an invisible tooltip.
-    //
-    // zip together the corresponding hover and definition
-    subscription.add(
-        combineLatest(
-            zip(hoverObservables, actionObservables),
-            resolvedPositionEvents.pipe(map(({ eventType }) => eventType))
-        )
-            .pipe(
-                switchMap(([[hoverObservable, actionObservable], eventType]) => {
-                    // If the position was triggered by a mouseover, never pin
-                    if (eventType !== 'click' && eventType !== 'jump') {
-                        return [false]
-                    }
-                    // combine the latest values for them, so we have access to both values
-                    // and can reevaluate our pinning decision whenever one of the two updates,
-                    // independent of the order in which they emit
-                    return combineLatest(hoverObservable, actionObservable).pipe(
-                        map(([{ hoverOrError }, actionsOrError]) =>
-                            // In the time between the click/jump and the loader being displayed,
-                            // pin the hover overlay so mouseover events get ignored
-                            // If the hover comes back empty (and the definition) it will get unpinned again
-                            Boolean(hoverOrError === undefined || (actionsOrError && !isErrorLike(actionsOrError)))
-                        )
-                    )
-                })
+    if (pinningEnabled) {
+        // DEFERRED HOVER OVERLAY PINNING
+        // If the new position came from a click or the URL,
+        // if either the hover or the definition turn out non-empty, pin the tooltip.
+        // If they both turn out empty, unpin it so we don't end up with an invisible tooltip.
+        //
+        // zip together the corresponding hover and definition
+        subscription.add(
+            combineLatest(
+                zip(hoverObservables, actionObservables),
+                resolvedPositionEvents.pipe(map(({ eventType }) => eventType))
             )
-            .subscribe(hoverOverlayIsFixed => {
-                container.update({ hoverOverlayIsFixed })
-            })
-    )
+                .pipe(
+                    switchMap(([[hoverObservable, actionObservable], eventType]) => {
+                        // If the position was triggered by a mouseover, never pin
+                        if (eventType !== 'click' && eventType !== 'jump') {
+                            return [false]
+                        }
+                        // combine the latest values for them, so we have access to both values
+                        // and can reevaluate our pinning decision whenever one of the two updates,
+                        // independent of the order in which they emit
+                        return combineLatest(hoverObservable, actionObservable).pipe(
+                            map(([{ hoverOrError }, actionsOrError]) =>
+                                // In the time between the click/jump and the loader being displayed,
+                                // pin the hover overlay so mouseover events get ignored
+                                // If the hover comes back empty (and the definition) it will get unpinned again
+                                Boolean(hoverOrError === undefined || (actionsOrError && !isErrorLike(actionsOrError)))
+                            )
+                        )
+                    })
+                )
+                .subscribe(hoverOverlayIsFixed => {
+                    container.update({ hoverOverlayIsFixed })
+                })
+        )
+    }
 
     const resetHover = () => {
         container.update({

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -198,9 +198,9 @@ export interface HoverifyOptions<C extends object>
  */
 export interface HoverState<C extends object, D, A> {
     /**
-     * The hovered and highlighted HTML element.
+     * The currently hovered and highlighted HTML element.
      */
-    token?: HTMLElement
+    hoveredTokenElement?: HTMLElement
 
     /**
      * Actions for the current token.
@@ -231,7 +231,6 @@ export interface HoverState<C extends object, D, A> {
  * @template A The type of an action.
  */
 interface InternalHoverifierState<C extends object, D, A> {
-    token?: HTMLElement
     hoverOrError?: typeof LOADING | (HoverAttachment & D) | null | ErrorLike
 
     hoverOverlayIsFixed: boolean
@@ -241,6 +240,9 @@ interface InternalHoverifierState<C extends object, D, A> {
 
     /** The currently hovered token */
     hoveredToken?: HoveredToken & C
+
+    /** The currently hovered token HTML element */
+    hoveredTokenElement?: HTMLElement
 
     /**
      * The highlighted range, which is the range in the hoverOrError data or else the range of the hovered token.
@@ -290,7 +292,7 @@ const shouldRenderOverlay = (state: InternalHoverifierState<{}, {}, {}>): boolea
 const internalToExternalState = <C extends object, D, A>(
     internalState: InternalHoverifierState<C, D, A>
 ): HoverState<C, D, A> => ({
-    token: internalState.token,
+    hoveredTokenElement: internalState.hoveredTokenElement,
     actionsOrError: internalState.actionsOrError,
     selectedPosition: internalState.selectedPosition,
     highlightedRange: shouldRenderOverlay(internalState) ? internalState.highlightedRange : undefined,
@@ -351,7 +353,7 @@ export function createHoverifier<C extends object, D, A>({
     // Internal state that is not exposed to the caller
     // Shared between all hoverified code views
     const container = createObservableStateContainer<InternalHoverifierState<C, D, A>>({
-        token: undefined,
+        hoveredTokenElement: undefined,
         hoverOverlayIsFixed: false,
         hoveredToken: undefined,
         hoverOrError: undefined,
@@ -720,11 +722,11 @@ export function createHoverifier<C extends object, D, A>({
                     currentHighlighted.classList.remove('selection-highlight')
                 }
                 if (!highlightedRange) {
-                    container.update({ token: undefined })
+                    container.update({ hoveredTokenElement: undefined })
                     return
                 }
                 const token = getTokenAtPosition(codeView, highlightedRange.start, dom, part)
-                container.update({ token })
+                container.update({ hoveredTokenElement: token })
                 if (!token) {
                     return
                 }

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -474,7 +474,11 @@ export function createHoverifier<C extends object, D, A>({
         share()
     )
 
-    /** Emits DOM elements at new positions found in the URL */
+    /**
+     * Emits DOM elements at new positions found in the URL. When pinning is
+     * disabled, this does not emit at all because the tooltip doesn't get
+     * pinned at the jump target.
+     */
     const jumpTargets = pinningEnabled
         ? allPositionJumps.pipe(
               // Only use line and character for comparison

--- a/src/testutils/fixtures.ts
+++ b/src/testutils/fixtures.ts
@@ -12,7 +12,7 @@ export const createHoverAttachment = (hover: Partial<HoverAttachment> = {}): Hov
     range: hover.range
         ? hover.range
         : {
-              start: { line: 24, character: 5 },
+              start: { line: 24, character: 10 },
               end: { line: 24, character: 14 },
           },
 })


### PR DESCRIPTION
This will let Sourcegraph provide single-click jump-to-definition behavior:

![2019-04-16 14 57 36](https://user-images.githubusercontent.com/1387653/56247089-9124b000-6058-11e9-8e92-0174ed5ccee8.gif)

Subsumes https://github.com/sourcegraph/codeintellify/pull/42 cc @dadlerj just FYI