### PR TITLE
feat: conditionally tokenize cells

### DIFF
--- a/src/hoverifier.test.ts
+++ b/src/hoverifier.test.ts
@@ -50,7 +50,7 @@ describe('Hoverifier', () => {
 
                 const positionJumps = new Subject<PositionJump>()
 
-                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents(codeView))
+                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents({ domFunctions: codeView }))
 
                 const subscriptions = new Subscription()
 
@@ -112,7 +112,7 @@ describe('Hoverifier', () => {
 
                 const positionJumps = new Subject<PositionJump>()
 
-                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents(codeView))
+                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents({ domFunctions: codeView }))
 
                 const subscriptions = new Subscription()
 
@@ -201,7 +201,7 @@ describe('Hoverifier', () => {
 
                 const positionJumps = new Subject<PositionJump>()
 
-                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents(codeView))
+                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents({ domFunctions: codeView }))
 
                 const subscriptions = new Subscription()
 
@@ -282,7 +282,7 @@ describe('Hoverifier', () => {
 
                 const positionJumps = new Subject<PositionJump>()
 
-                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents(codeView))
+                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents({ domFunctions: codeView }))
 
                 const subscriptions = new Subscription()
 
@@ -346,7 +346,9 @@ describe('Hoverifier', () => {
 
                     const positionJumps = new Subject<PositionJump>()
 
-                    const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents(codeView))
+                    const positionEvents = of(codeView.codeView).pipe(
+                        findPositionsFromEvents({ domFunctions: codeView })
+                    )
 
                     const subscriptions = new Subscription()
 
@@ -416,7 +418,9 @@ describe('Hoverifier', () => {
 
                     const positionJumps = new Subject<PositionJump>()
 
-                    const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents(codeView))
+                    const positionEvents = of(codeView.codeView).pipe(
+                        findPositionsFromEvents({ domFunctions: codeView })
+                    )
 
                     const subscriptions = new Subscription()
 
@@ -495,7 +499,7 @@ describe('Hoverifier', () => {
 
                 const positionJumps = new Subject<PositionJump>()
 
-                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents(codeView))
+                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents({ domFunctions: codeView }))
 
                 const subscriptions = new Subscription()
 
@@ -567,7 +571,7 @@ describe('Hoverifier', () => {
 
                 const positionJumps = new Subject<PositionJump>()
 
-                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents(codeView))
+                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents({ domFunctions: codeView }))
 
                 const subscriptions = new Subscription()
 
@@ -629,7 +633,7 @@ describe('Hoverifier', () => {
 
                 const positionJumps = new Subject<PositionJump>()
 
-                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents(codeView))
+                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents({ domFunctions: codeView }))
 
                 const subscriptions = new Subscription()
 
@@ -712,7 +716,7 @@ describe('Hoverifier', () => {
 
                 const positionJumps = new Subject<PositionJump>()
 
-                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents(codeView))
+                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents({ domFunctions: codeView }))
 
                 const subscriptions = new Subscription()
 
@@ -766,7 +770,7 @@ describe('Hoverifier', () => {
                     pinningEnabled: true,
                 })
                 const positionJumps = new Subject<PositionJump>()
-                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents(codeView))
+                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents({ domFunctions: codeView }))
 
                 const codeViewSubscription = hoverifier.hoverify({
                     dom: codeView,
@@ -807,7 +811,9 @@ describe('Hoverifier', () => {
                     pinningEnabled: true,
                 })
                 const positionJumps = new Subject<PositionJump>()
-                const positionEvents = of(codeViewProps.codeView).pipe(findPositionsFromEvents(codeViewProps))
+                const positionEvents = of(codeViewProps.codeView).pipe(
+                    findPositionsFromEvents({ domFunctions: codeViewProps })
+                )
 
                 const codeViewSubscription = hoverifier.hoverify({
                     dom: codeViewProps,

--- a/src/positions.test.ts
+++ b/src/positions.test.ts
@@ -4,7 +4,7 @@ import { filter, map } from 'rxjs/operators'
 import { TestScheduler } from 'rxjs/testing'
 
 import { CodeViewProps, DOM } from './testutils/dom'
-import { dispatchMouseEventAtPositionImpure, createMouseEvent } from './testutils/mouse'
+import { createMouseEvent, dispatchMouseEventAtPositionImpure } from './testutils/mouse'
 
 import { propertyIsDefined } from './helpers'
 import { findPositionsFromEvents } from './positions'

--- a/src/positions.test.ts
+++ b/src/positions.test.ts
@@ -43,7 +43,7 @@ describe('positions', () => {
                 }
 
                 const clickedTokens = of(codeView.codeView).pipe(
-                    findPositionsFromEvents(codeView),
+                    findPositionsFromEvents({ domFunctions: codeView }),
                     filter(propertyIsDefined('position')),
                     map(({ position: { line, character } }) => ({ line, character }))
                 )

--- a/src/positions.test.ts
+++ b/src/positions.test.ts
@@ -4,7 +4,7 @@ import { filter, map } from 'rxjs/operators'
 import { TestScheduler } from 'rxjs/testing'
 
 import { CodeViewProps, DOM } from './testutils/dom'
-import { dispatchMouseEventAtPositionImpure } from './testutils/mouse'
+import { dispatchMouseEventAtPositionImpure, createMouseEvent } from './testutils/mouse'
 
 import { propertyIsDefined } from './helpers'
 import { findPositionsFromEvents } from './positions'
@@ -56,4 +56,29 @@ describe('positions', () => {
             })
         }
     })
+
+    for (const tokenize of [false, true]) {
+        for (const codeView of testcases) {
+            it((tokenize ? 'tokenizes' : 'does not tokenize') + ` the DOM when tokenize: ${tokenize}`, () => {
+                of(codeView.codeView)
+                    .pipe(findPositionsFromEvents({ domFunctions: codeView, tokenize }))
+                    .subscribe()
+
+                const htmlBefore = codeView.getCodeElementFromLineNumber(codeView.codeView, 5)!.outerHTML
+                codeView.getCodeElementFromLineNumber(codeView.codeView, 5)!.dispatchEvent(
+                    createMouseEvent('mouseover', {
+                        x: 0,
+                        y: 0,
+                    })
+                )
+                const htmlAfter = codeView.getCodeElementFromLineNumber(codeView.codeView, 5)!.outerHTML
+
+                if (tokenize) {
+                    chai.expect(htmlBefore).to.not.equal(htmlAfter)
+                } else {
+                    chai.expect(htmlBefore).to.equal(htmlAfter)
+                }
+            })
+        }
+    }
 })

--- a/src/positions.ts
+++ b/src/positions.ts
@@ -28,7 +28,7 @@ export interface PositionEvent {
 export { DOMFunctions, DiffPart }
 export const findPositionsFromEvents = ({
     domFunctions,
-    tokenize = false,
+    tokenize = true,
 }: {
     domFunctions: DOMFunctions
     tokenize?: boolean

--- a/src/positions.ts
+++ b/src/positions.ts
@@ -31,7 +31,7 @@ export const findPositionsFromEvents = ({
     tokenize = false,
 }: {
     domFunctions: DOMFunctions
-    tokenize: boolean
+    tokenize?: boolean
 }) => (elements: Subscribable<HTMLElement>): Observable<PositionEvent> =>
     merge(
         from(elements).pipe(

--- a/src/positions.ts
+++ b/src/positions.ts
@@ -26,9 +26,13 @@ export interface PositionEvent {
 }
 
 export { DOMFunctions, DiffPart }
-export const findPositionsFromEvents = (options: DOMFunctions) => (
-    elements: Subscribable<HTMLElement>
-): Observable<PositionEvent> =>
+export const findPositionsFromEvents = ({
+    domFunctions,
+    tokenize = false,
+}: {
+    domFunctions: DOMFunctions
+    tokenize: boolean
+}) => (elements: Subscribable<HTMLElement>): Observable<PositionEvent> =>
     merge(
         from(elements).pipe(
             switchMap(element =>
@@ -46,7 +50,10 @@ export const findPositionsFromEvents = (options: DOMFunctions) => (
             // If not done for this cell, wrap the tokens in this cell to enable finding the precise positioning.
             // This may be possible in other ways (looking at mouse position and rendering characters), but it works
             tap(({ target }) => {
-                const code = options.getCodeElementFromTarget(target)
+                if (!tokenize) {
+                    return
+                }
+                const code = domFunctions.getCodeElementFromTarget(target)
                 if (code) {
                     convertCodeElementIdempotent(code)
                 }
@@ -72,7 +79,7 @@ export const findPositionsFromEvents = (options: DOMFunctions) => (
     ).pipe(
         // Find out the position that was hovered over
         map(({ target, codeView, ...rest }) => {
-            const hoveredToken = locateTarget(target, options)
+            const hoveredToken = locateTarget(target, domFunctions)
             const position = isPosition(hoveredToken) ? hoveredToken : undefined
             return { position, codeView, ...rest }
         })


### PR DESCRIPTION
Motivation: some code hosts have already tokenized the code view (e.g. Bitbucket). The tokenization currently prevents text selection from working on Bitbucket https://github.com/sourcegraph/sourcegraph/issues/4051

Implementation: this lets callers specify a boolean `tokenize` to control whether or not tokenization occurs.

Slack conversation https://sourcegraph.slack.com/archives/CHXHX7XAS/p1559599129008000