### PR TITLE
chore: don't use replace for devDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,10 +5,6 @@
     {
       "depTypeList": ["dependencies"],
       "rangeStrategy": "widen"
-    },
-    {
-      "depTypeList": ["devDependencies"],
-      "rangeStrategy": "replace"
     }
   ]
 }


### PR DESCRIPTION
This prevents minor updates.
Use the inherited "bump" strategy.