### PR TITLE
feat: add HoverifyOptions.scrollBoundaries

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -33,7 +33,7 @@ export const scrollIntoCenterIfNeeded = (container: HTMLElement, content: HTMLEl
 }
 
 /**
- * Returns a curried function that retusn `true` if `e1` and `e2` overlap.
+ * Returns a curried function that returns `true` if `e1` and `e2` overlap.
  */
 export const elementOverlaps = (e1: HTMLElement) => (e2: HTMLElement): boolean => {
     const e1Rect = e1.getBoundingClientRect()

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -31,3 +31,17 @@ export const scrollIntoCenterIfNeeded = (container: HTMLElement, content: HTMLEl
         container.scrollTop = scrollTop
     }
 }
+
+/**
+ * Returns a curried function that retusn `true` if `e1` and `e2` overlap.
+ */
+export const elementOverlaps = (e1: HTMLElement) => (e2: HTMLElement) => {
+    const e1Rect = e1.getBoundingClientRect()
+    const e2Rect = e2.getBoundingClientRect()
+    return !(
+        e1Rect.right < e2Rect.left ||
+        e1Rect.left > e2Rect.right ||
+        e1Rect.bottom < e2Rect.top ||
+        e1Rect.top > e2Rect.bottom
+    )
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -35,7 +35,7 @@ export const scrollIntoCenterIfNeeded = (container: HTMLElement, content: HTMLEl
 /**
  * Returns a curried function that retusn `true` if `e1` and `e2` overlap.
  */
-export const elementOverlaps = (e1: HTMLElement) => (e2: HTMLElement) => {
+export const elementOverlaps = (e1: HTMLElement) => (e2: HTMLElement): boolean => {
     const e1Rect = e1.getBoundingClientRect()
     const e2Rect = e2.getBoundingClientRect()
     return !(

--- a/testdata/github/generate.ts
+++ b/testdata/github/generate.ts
@@ -19,6 +19,7 @@ export function generateGithubCodeTable(lines: string[]): string {
       </style>
       <div class="container">
           <div class="file">
+              <div class="file-header sticky-file-header"></div>
               <div itemprop="text" class="blob-wrapper data">
                   <table><tbody>${code}</tbody></table>
               </div>

--- a/testdata/github/styles.css
+++ b/testdata/github/styles.css
@@ -10,6 +10,21 @@
   color: #24292e;
 }
 
+.github-testcase .sticky-file-header {
+    position: sticky;
+    z-index: 6;
+    top: 0px;
+}
+
+.github-testcase .file-header {
+    height: 60px;
+    padding: 5px 10px;
+    background-color: #fafbfc;
+    border-bottom: 1px solid #e1e4e8;
+    border-top-left-radius: 2px;
+    border-top-right-radius: 2px;
+}
+
 .github-testcase .container {
   width: 980px;
   margin-right: auto;


### PR DESCRIPTION
Rel  [RFC 76](https://docs.google.com/document/d/1albi6HaAU9JAqdQXjsE-50NidxG4icE-36XqxxKgfM4/edit)

Introduces `HoverifyOptions.scrollBoundaries`, an array of `HTMLElement`, which would typically contain elements with a lower z-index than the hover overlay but a higher z-index than the code view, such as a sticky file header.

At runtime, in reaction to scroll events, hide the hover overlay when it overlaps with a hover boundary.

`IntersectionObserver` could not be used here, as it requires an ancestor relationship between the root and target elements.

**Before**:

<details>
<img src="https://user-images.githubusercontent.com/1741180/70099753-c426ae80-15fd-11ea-9332-2323b1679b48.gif" title="Broken"/>
</details>

**After**:

<details>
<img src="https://user-images.githubusercontent.com/1741180/70099787-d6a0e800-15fd-11ea-8849-ef6f777f81f5.gif" title="Fixed"/>
</details>