### PR TITLE
chore: upgrade TypeScript and modernize practices

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^3.0.5",
     "mocha": "^6.1.4",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "raw-loader": "^3.0.0",
     "rimraf": "^2.6.3",
     "semantic-release": "^15.6.3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "sourcegraph": "^23.0.1",
     "ts-node": "^8.2.0",
     "tslint": "^5.20.0",
-    "typescript": "^3.5.1",
+    "typescript": "^3.7.4",
     "webpack": "^4.33.0",
     "webpack-cli": "^3.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/karma-webpack": "2.0.7",
     "@types/lodash": "4.14.149",
     "@types/mocha": "5.2.7",
-    "@types/node": "10.9.4",
+    "@types/node": "12.12.21",
     "@types/sinon": "7.0.13",
     "@types/webpack": "4.4.32",
     "@types/webpack-env": "1.14.1",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,7 +4,7 @@ export interface ErrorLike {
 }
 
 export const isErrorLike = (val: any): val is ErrorLike =>
-    !!val && typeof val === 'object' && (!!val.stack || ('message' in val || 'code' in val)) && !('__typename' in val)
+    !!val && typeof val === 'object' && (!!val.stack || 'message' in val || 'code' in val) && !('__typename' in val)
 
 /**
  * Ensures a value is a proper Error, copying all properties if needed

--- a/src/hoverifier.test.ts
+++ b/src/hoverifier.test.ts
@@ -587,7 +587,7 @@ describe('Hoverifier', () => {
 
                 const outputValues: {
                     [key: string]: {
-                        hoverOrError: typeof LOADING | (HoverAttachment) | null | ErrorLike
+                        hoverOrError: typeof LOADING | HoverAttachment | null | ErrorLike
                         actionsOrError: typeof LOADING | string[] | null | ErrorLike
                     }
                 } = {

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -623,10 +623,7 @@ export function createHoverifier<C extends object, D, A>({
     /**
      * An Observable of scroll events on the document.
      */
-    const scrollEvents = fromEvent(document, 'scroll').pipe(
-        observeOn(animationFrameScheduler),
-        share()
-    )
+    const scrollEvents = fromEvent(document, 'scroll').pipe(observeOn(animationFrameScheduler), share())
 
     /**
      * Returns the highlighted range for the given hover result and position.
@@ -674,9 +671,10 @@ export function createHoverifier<C extends object, D, A>({
         scrollBoundaries,
         ...rest
     }: Omit<InternalHoverifierState<C, D, A>, 'mouseIsMoving' | 'hoverOverlayIsFixed'> &
-        Omit<EventOptions<C>, 'resolveContext' | 'dom'> & { codeView: HTMLElement }): Observable<
-        Omit<InternalHoverifierState<C, D, A>, 'mouseIsMoving' | 'hoverOverlayIsFixed'> & { codeView: HTMLElement }
-    > => {
+        Omit<EventOptions<C>, 'resolveContext' | 'dom'> & { codeView: HTMLElement }): Observable<Omit<
+        InternalHoverifierState<C, D, A>,
+        'mouseIsMoving' | 'hoverOverlayIsFixed'
+    > & { codeView: HTMLElement }> => {
         const result = of({ hoveredTokenElement, ...rest })
         if (!hoveredTokenElement || !scrollBoundaries) {
             return result
@@ -702,20 +700,18 @@ export function createHoverifier<C extends object, D, A>({
      * For every position, emits an Observable with new values for the `hoverOrError` state.
      * This is a higher-order Observable (Observable that emits Observables).
      */
-    const hoverObservables: Observable<
-        Observable<{
-            eventType: SupportedMouseEvent | 'jump'
-            dom: DOMFunctions
-            target: HTMLElement
-            adjustPosition?: PositionAdjuster<C>
-            codeView: HTMLElement
-            codeViewId: symbol
-            scrollBoundaries?: HTMLElement[]
-            hoverOrError?: typeof LOADING | (HoverAttachment & D) | ErrorLike | null
-            position?: HoveredToken & C
-            part?: DiffPart
-        }>
-    > = resolvedPositions.pipe(
+    const hoverObservables: Observable<Observable<{
+        eventType: SupportedMouseEvent | 'jump'
+        dom: DOMFunctions
+        target: HTMLElement
+        adjustPosition?: PositionAdjuster<C>
+        codeView: HTMLElement
+        codeViewId: symbol
+        scrollBoundaries?: HTMLElement[]
+        hoverOrError?: typeof LOADING | (HoverAttachment & D) | ErrorLike | null
+        position?: HoveredToken & C
+        part?: DiffPart
+    }>> = resolvedPositions.pipe(
         map(({ position, codeViewId, ...rest }) => {
             if (!position) {
                 return of({ hoverOrError: null, position: undefined, part: undefined, codeViewId, ...rest })
@@ -728,14 +724,7 @@ export function createHoverifier<C extends object, D, A>({
             // 1. Reset the hover content, so no old hover content is displayed at the new position while getting
             // 2. Show a loader if the hover hasn't returned after 100ms
             // 3. Show the hover once it returned
-            return merge(
-                [undefined],
-                of(LOADING).pipe(
-                    delay(LOADER_DELAY),
-                    takeUntil(hover)
-                ),
-                hover
-            ).pipe(
+            return merge([undefined], of(LOADING).pipe(delay(LOADER_DELAY), takeUntil(hover)), hover).pipe(
                 map(hoverOrError => ({
                     ...rest,
                     codeViewId,

--- a/src/overlay_position.test.ts
+++ b/src/overlay_position.test.ts
@@ -47,7 +47,7 @@ describe('overlay_position', () => {
                     position: absolute;
                 }
             `
-            document.head!.appendChild(style)
+            document.head.appendChild(style)
 
             relativeElement = document.createElement('div')
             relativeElement.className = 'relative-element'

--- a/src/testutils/dom.ts
+++ b/src/testutils/dom.ts
@@ -187,7 +187,7 @@ const createSourcegraphCodeView = (): CodeViewProps => {
  */
 export class DOM {
     /** The inserted nodes. We save them so that we can remove them on cleanup. */
-    private nodes = new Set<Element>()
+    private readonly nodes = new Set<Element>()
 
     /**
      * Creates and inserts the generated test cases into the DOM
@@ -211,7 +211,7 @@ export class DOM {
     public createElementFromString(html: string): HTMLDivElement {
         const element = createElementFromString(html)
         this.insert(element)
-        return element as HTMLDivElement
+        return element
     }
 
     /**

--- a/src/testutils/fixtures.ts
+++ b/src/testutils/fixtures.ts
@@ -26,7 +26,7 @@ export function createStubHoverProvider(
     hover: Partial<HoverAttachment> = {},
     delayTime?: number
 ): HoverProvider<{}, {}> {
-    return () => of(createHoverAttachment(hover)).pipe(delay(delayTime || 0))
+    return () => of(createHoverAttachment(hover)).pipe(delay(delayTime ?? 0))
 }
 
 /**
@@ -37,5 +37,5 @@ export function createStubHoverProvider(
  * @param delayTime optionally delay the fetch
  */
 export function createStubActionsProvider<A>(actions: A[], delayTime?: number): ActionsProvider<{}, A> {
-    return () => of(actions).pipe(delay(delayTime || 0))
+    return () => of(actions).pipe(delay(delayTime ?? 0))
 }

--- a/src/token_position.test.ts
+++ b/src/token_position.test.ts
@@ -304,11 +304,14 @@ describe('token_positions', () => {
                 position: { line: 2, endLine: 4 },
                 getCodeElementFromLineNumber: (codeView, line) => codeView.children[line - 1] as HTMLElement,
             })
-            assert.deepStrictEqual(codeElements.map(({ line, element }) => ({ line, content: element.textContent })), [
-                { line: 2, content: 'Line 2' },
-                { line: 3, content: 'Line 3' },
-                { line: 4, content: 'Line 4' },
-            ])
+            assert.deepStrictEqual(
+                codeElements.map(({ line, element }) => ({ line, content: element.textContent })),
+                [
+                    { line: 2, content: 'Line 2' },
+                    { line: 3, content: 'Line 3' },
+                    { line: 4, content: 'Line 4' },
+                ]
+            )
         })
 
         it('returns all code elements within a given range on a diff code view')

--- a/src/token_position.ts
+++ b/src/token_position.ts
@@ -109,7 +109,7 @@ export function convertNode(parentNode: HTMLElement): void {
         const isLastNode = i === parentNode.childNodes.length - 1
 
         if (node.nodeType === Node.TEXT_NODE) {
-            let nodeText = node.textContent || ''
+            let nodeText = node.textContent ?? ''
             if (nodeText === '') {
                 continue
             }
@@ -160,7 +160,7 @@ const enum TokenType {
  * @param node The node containing the token.
  */
 function getTokenType(node: Node): TokenType {
-    const text = node.textContent || ''
+    const text = node.textContent ?? ''
     if (text.length === 0) {
         return TokenType.Other
     }
@@ -271,7 +271,7 @@ export function findElementWithOffset(
     // Find the text node that is at the given offset.
     let targetNode: Node | undefined
     for (const [i, node] of textNodes.entries()) {
-        const text = node.textContent || ''
+        const text = node.textContent ?? ''
         if (offsetStep <= offset && offsetStep + text.length > offset) {
             targetNode = node
             nodeIndex = i
@@ -392,7 +392,7 @@ export function locateTarget(
         return { line }
     }
 
-    const part = getDiffCodePart && getDiffCodePart(codeElement)
+    const part = getDiffCodePart?.(codeElement)
     let ignoreFirstCharacter = !!isFirstCharacterDiffIndicator && isFirstCharacterDiffIndicator(codeElement)
 
     let character = 1
@@ -489,7 +489,7 @@ export const getTokenAtPosition = (
         return undefined
     }
     // On diff pages, account for the +/- indicator
-    if (isFirstCharacterDiffIndicator && isFirstCharacterDiffIndicator(codeElement)) {
+    if (isFirstCharacterDiffIndicator?.(codeElement)) {
         character++
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7494,10 +7494,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
-  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
+typescript@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 uglify-js@^3.1.4:
   version "3.4.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,10 +484,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
   integrity sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==
 
-"@types/node@10.9.4":
-  version "10.9.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
-  integrity sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==
+"@types/node@12.12.21":
+  version "12.12.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.21.tgz#aa44a6363291c7037111c47e4661ad210aded23f"
+  integrity sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5930,10 +5930,15 @@ prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@^1.17.0, prettier@^1.18.2:
+prettier@^1.17.0:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 process-nextick-args@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Use nullish coalescing, prefer readonly, and other TypeScript eslint fixes
- Upgrade TypeScript to a version that definitely supports these new features