### PR TITLE
fix: use error names, not error codes

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,10 +1,10 @@
 export interface ErrorLike {
     message: string
-    code?: string
+    name?: string
 }
 
 export const isErrorLike = (val: any): val is ErrorLike =>
-    !!val && typeof val === 'object' && (!!val.stack || 'message' in val || 'code' in val) && !('__typename' in val)
+    typeof val === 'object' && val !== null && ('message' in val || 'stack' in val) && !('__typename' in val)
 
 /**
  * Ensures a value is a proper Error, copying all properties if needed


### PR DESCRIPTION
Errors in ECMAScript have a `message` and a `name`. `code` is something Node-specific, and those errors still all have `name`. Native errors like `TypeError`, `URIError`, `AggregateError` (coming soon) all only have `name`. When we send errors to/from background pages or web workers, we can only reasonably expect `name` to be present, so we should never rely on `code`. See e.g. https://github.com/mozilla/webextension-polyfill/issues/210 or `comlink` source code.

Using both in our codebase inconsistently opens the risk to checking for the wrong property, (especially because errors are `any` in TypeScript) and adds additional code.

This change removes all uses of `code` in favor of `name`. There is still a case for having `name` be optional (e.g. GraphQL errors don't have a `name`, but do have `message`), so `ErrorLike` is still kept for now but we could think about just using the native `Error` interface in the future.