### PR TITLE
feat: allow hover providers to communicate loading state

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@sourcegraph/event-positions": "^1.0.4",
     "@sourcegraph/extension-api-types": "^2.0.0",
     "lodash": "^4.17.10",
-    "rxjs": "^6.3.3",
+    "rxjs": "^6.5.5",
     "ts-key-enum": "^2.0.0"
   },
   "devDependencies": {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,24 @@
+import { MaybeLoadingResult } from './loading'
+import { Subscribable } from 'sourcegraph'
+import { Observable, from } from 'rxjs'
+import { isObject } from 'lodash'
+import { map } from 'rxjs/operators'
+
+/**
+ * Checks if the given value is thenable.
+ */
+const isPromiseLike = (value: unknown): value is PromiseLike<unknown> =>
+    isObject(value) && typeof (value as PromiseLike<unknown>).then === 'function'
+
+/**
+ * Converts a provider result, which can be a continuously-updating, maybe-loading Subscribable, or a Promise for a
+ * single result, to the same type.
+ */
+export const toMaybeLoadingProviderResult = <T>(
+    value: Subscribable<MaybeLoadingResult<T>> | PromiseLike<T>
+): Observable<MaybeLoadingResult<T>> =>
+    isPromiseLike(value) ? from(value).pipe(map(result => ({ isLoading: false, result }))) : from(value)
+
 /**
  * Returns true if `val` is not `null` or `undefined`
  */

--- a/src/hoverifier.test.ts
+++ b/src/hoverifier.test.ts
@@ -18,7 +18,9 @@ import { findPositionsFromEvents, SupportedMouseEvent } from './positions'
 import { CodeViewProps, DOM } from './testutils/dom'
 import { createHoverAttachment, createStubActionsProvider, createStubHoverProvider } from './testutils/fixtures'
 import { dispatchMouseEventAtPositionImpure } from './testutils/mouse'
-import { HoverAttachment, LOADING } from './types'
+import { HoverAttachment } from './types'
+import { LOADING } from './loading'
+
 const { assert } = chai
 
 describe('Hoverifier', () => {
@@ -391,7 +393,9 @@ describe('Hoverifier', () => {
                         hoverOverlayRerenders: EMPTY,
                         // Only show on line 24, not line 25 (which is the 2nd click event below).
                         getHover: position =>
-                            position.line === 24 ? createStubHoverProvider({}, delayTime)(position) : of(null),
+                            position.line === 24
+                                ? createStubHoverProvider({}, delayTime)(position)
+                                : of({ isLoading: false, result: null }),
                         getActions: position =>
                             position.line === 24
                                 ? createStubActionsProvider(['foo', 'bar'], delayTime)(position)
@@ -465,7 +469,10 @@ describe('Hoverifier', () => {
                         hoverOverlayElements: of(null),
                         hoverOverlayRerenders: EMPTY,
                         // Only show on line 24, not line 25 (which is the 2nd click event below).
-                        getHover: position => (position.line === 24 ? createStubHoverProvider({})(position) : of(null)),
+                        getHover: position =>
+                            position.line === 24
+                                ? createStubHoverProvider({})(position)
+                                : of({ isLoading: false, result: null }),
                         getActions: position =>
                             position.line === 24 ? createStubActionsProvider(['foo', 'bar'])(position) : of(null),
                         pinningEnabled: true,

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -335,8 +335,9 @@ export const TOOLTIP_DISPLAY_DELAY = 100
 export const MOUSEOVER_DELAY = 50
 
 /**
- * Function that returns a Subscribable of the hover result to be shown.
- * It may emit on the Observable to update the content and must indicate when it starts and stopped loading new content.
+ * Function that returns a Subscribable or PromiseLike of the hover result to be shown.
+ * If a Subscribable is returned, it may emit more than once to update the content,
+ * and must indicate when it starts and stopped loading new content.
  * It should emit a `null` result if the token has no hover content (e.g. whitespace, punctuation).
  *
  * @template C Extra context for the hovered token.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './hoverifier'
 export * from './positions'
 export { HoverOverlayProps } from './types'
+export * from './loading'

--- a/src/loading.test.ts
+++ b/src/loading.test.ts
@@ -1,6 +1,8 @@
 import { TestScheduler } from 'rxjs/testing'
 import { emitLoading, LOADING, MaybeLoadingResult } from './loading'
 
+const deepStrictEqual = chai.assert.deepStrictEqual.bind(chai.assert)
+
 const inputAlphabet: Record<'l' | 'e' | 'i' | 'r', MaybeLoadingResult<number | null>> = {
     // loading
     l: { isLoading: true, result: null },
@@ -27,56 +29,56 @@ const outputAlphabet = {
 
 describe('emitLoading()', () => {
     it('emits an empty result if the source emits an empty result before the loader delay', () => {
-        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        const scheduler = new TestScheduler(deepStrictEqual)
         scheduler.run(({ cold, expectObservable }) => {
             const source = cold('l 10ms e', inputAlphabet)
             expectObservable(source.pipe(emitLoading(300, null))).toBe('u 10ms e', outputAlphabet)
         })
     })
     it('emits a loader if the source has not emitted after the loader delay', () => {
-        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        const scheduler = new TestScheduler(deepStrictEqual)
         scheduler.run(({ cold, expectObservable }) => {
             const source = cold('400ms r', inputAlphabet)
             expectObservable(source.pipe(emitLoading(300, null))).toBe('u 299ms l 99ms r', outputAlphabet)
         })
     })
     it('emits a loader if the source has not emitted a result after the loader delay', () => {
-        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        const scheduler = new TestScheduler(deepStrictEqual)
         scheduler.run(({ cold, expectObservable }) => {
             const source = cold('l 400ms r', inputAlphabet)
             expectObservable(source.pipe(emitLoading(300, null))).toBe('u 299ms l 100ms r', outputAlphabet)
         })
     })
     it('emits a loader if the source first emits an empty result, but then starts loading again', () => {
-        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        const scheduler = new TestScheduler(deepStrictEqual)
         scheduler.run(({ cold, expectObservable }) => {
             const source = cold('e 10ms l 400ms r', inputAlphabet)
             expectObservable(source.pipe(emitLoading(300, null))).toBe('(ue) 296ms l 111ms r', outputAlphabet)
         })
     })
     it('emits a loader if the source first emits an empty result, but then starts loading again after the loader delay already passed', () => {
-        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        const scheduler = new TestScheduler(deepStrictEqual)
         scheduler.run(({ cold, expectObservable }) => {
             const source = cold('e 400ms l 400ms r', inputAlphabet)
             expectObservable(source.pipe(emitLoading(300, null))).toBe('(ue) 397ms l 400ms r', outputAlphabet)
         })
     })
     it('hides the loader when the source emits an empty result', () => {
-        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        const scheduler = new TestScheduler(deepStrictEqual)
         scheduler.run(({ cold, expectObservable }) => {
             const source = cold('l 400ms e', inputAlphabet)
             expectObservable(source.pipe(emitLoading(300, null))).toBe('u 299ms l 100ms e', outputAlphabet)
         })
     })
     it('emits intermediate results before the loader delay', () => {
-        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        const scheduler = new TestScheduler(deepStrictEqual)
         scheduler.run(({ cold, expectObservable }) => {
             const source = cold('l 10ms i 10ms r', inputAlphabet)
             expectObservable(source.pipe(emitLoading(300, null))).toBe('u 10ms i 10ms r', outputAlphabet)
         })
     })
     it('emits intermediate results after the loader delay and showing a loader', () => {
-        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        const scheduler = new TestScheduler(deepStrictEqual)
         scheduler.run(({ cold, expectObservable }) => {
             const source = cold('l 400ms i 10ms r', inputAlphabet)
             expectObservable(source.pipe(emitLoading(300, null))).toBe('u 299ms l 100ms i 10ms r', outputAlphabet)

--- a/src/loading.test.ts
+++ b/src/loading.test.ts
@@ -42,6 +42,34 @@ describe('emitLoading()', () => {
             expectObservable(source.pipe(emitLoading(300, null))).toBe('u 299ms l 99ms r', outputAlphabet)
         })
     })
+    it('emits an empty result if the source completes without a result', () => {
+        const scheduler = new TestScheduler(deepStrictEqual)
+        scheduler.run(({ cold, expectObservable }) => {
+            const source = cold('400ms |', inputAlphabet)
+            expectObservable(source.pipe(emitLoading(300, null))).toBe('u 299ms l 99ms (e|)', outputAlphabet)
+        })
+    })
+    it('emits an empty result if the source completes without a result before the loader delay', () => {
+        const scheduler = new TestScheduler(deepStrictEqual)
+        scheduler.run(({ cold, expectObservable }) => {
+            const source = cold('10ms |', inputAlphabet)
+            expectObservable(source.pipe(emitLoading(300, null))).toBe('u 9ms (e|)', outputAlphabet)
+        })
+    })
+    it('emits an empty result if the source completes after an empty loading result', () => {
+        const scheduler = new TestScheduler(deepStrictEqual)
+        scheduler.run(({ cold, expectObservable }) => {
+            const source = cold('l 400ms |', inputAlphabet)
+            expectObservable(source.pipe(emitLoading(300, null))).toBe('u 299ms l 100ms (e|)', outputAlphabet)
+        })
+    })
+    it('emits the last result if the source completes after an intermediate non-empty loading result', () => {
+        const scheduler = new TestScheduler(deepStrictEqual)
+        scheduler.run(({ cold, expectObservable }) => {
+            const source = cold('-i-|', inputAlphabet)
+            expectObservable(source.pipe(emitLoading(300, null))).toBe('ui-(i|)', outputAlphabet)
+        })
+    })
     it('emits a loader if the source has not emitted a result after the loader delay', () => {
         const scheduler = new TestScheduler(deepStrictEqual)
         scheduler.run(({ cold, expectObservable }) => {

--- a/src/loading.test.ts
+++ b/src/loading.test.ts
@@ -70,6 +70,14 @@ describe('emitLoading()', () => {
             expectObservable(source.pipe(emitLoading(300, null))).toBe('ui-(i|)', outputAlphabet)
         })
     })
+    it('errors if the source errors', () => {
+        const scheduler = new TestScheduler(deepStrictEqual)
+        scheduler.run(({ cold, expectObservable }) => {
+            const error = new Error('test')
+            const source = cold('10ms #', inputAlphabet, error)
+            expectObservable(source.pipe(emitLoading(300, null))).toBe('u 9ms #', outputAlphabet, error)
+        })
+    })
     it('emits a loader if the source has not emitted a result after the loader delay', () => {
         const scheduler = new TestScheduler(deepStrictEqual)
         scheduler.run(({ cold, expectObservable }) => {

--- a/src/loading.test.ts
+++ b/src/loading.test.ts
@@ -1,0 +1,67 @@
+import { TestScheduler } from 'rxjs/testing'
+import { emitLoading, LOADING, MaybeLoadingResult } from './loading'
+
+const inputAlphabet: Record<'l' | 'e' | 'r', MaybeLoadingResult<number | null>> = {
+    // loading
+    l: { isLoading: true, result: null },
+    // empty
+    e: { isLoading: false, result: null },
+    // result
+    r: { isLoading: false, result: 1 },
+}
+
+const outputAlphabet = {
+    // undefined
+    u: undefined,
+    // empty
+    e: null,
+    // loading
+    l: LOADING,
+    // result
+    r: inputAlphabet.r.result,
+}
+
+describe('emitLoading()', () => {
+    it('emits an empty result if the source emits an empty result before the loader delay', () => {
+        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        scheduler.run(({ cold, expectObservable }) => {
+            const source = cold('l 10ms e', inputAlphabet)
+            expectObservable(source.pipe(emitLoading(300, null))).toBe('u 10ms e', outputAlphabet)
+        })
+    })
+    it('emits a loader if the source has not emitted after the loader delay', () => {
+        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        scheduler.run(({ cold, expectObservable }) => {
+            const source = cold('400ms r', inputAlphabet)
+            expectObservable(source.pipe(emitLoading(300, null))).toBe('u 299ms l 99ms r', outputAlphabet)
+        })
+    })
+    it('emits a loader if the source has not emitted a result after the loader delay', () => {
+        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        scheduler.run(({ cold, expectObservable }) => {
+            const source = cold('l 400ms r', inputAlphabet)
+            expectObservable(source.pipe(emitLoading(300, null))).toBe('u 299ms l 100ms r', outputAlphabet)
+        })
+    })
+    it('emits a loader if the source first emits an empty result, but then starts loading again', () => {
+        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        scheduler.run(({ cold, expectObservable }) => {
+            const source = cold('e 10ms l 400ms r', inputAlphabet)
+            expectObservable(source.pipe(emitLoading(300, null))).toBe('(ue) 296ms l 111ms r', outputAlphabet)
+        })
+    })
+    it('emits a loader if the source first emits an empty result, but then starts loading again after the loader delay already passed', () => {
+        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        scheduler.run(({ cold, expectObservable }) => {
+            const source = cold('e 400ms l 400ms r', inputAlphabet)
+            expectObservable(source.pipe(emitLoading(300, null))).toBe('(ue) 397ms l 400ms r', outputAlphabet)
+        })
+    })
+    it('hides the loader when the source emits an empty result', () => {
+        const scheduler = new TestScheduler((a, b) => chai.assert.deepEqual(a, b))
+        scheduler.run(({ cold, expectObservable }) => {
+            const source = cold('l 400ms e', inputAlphabet)
+            expectObservable(source.pipe(emitLoading(300, null))).toBe('u 299ms l 100ms e', outputAlphabet)
+        })
+    })
+})

--- a/src/loading.ts
+++ b/src/loading.ts
@@ -22,11 +22,11 @@ export interface MaybeLoadingResult<T> {
 }
 
 /**
- * Handles input of MaybeLoadingResult (which contains both results and loading states) and returns a sequence of clear
+ * Maps a stream of MaybeLoadingResult (which contains both results and loading states) to a stream of clear
  * instructions on when to show a loader, results or nothing.
  *
- * @param loaderDelay After how many milliseconds of no results a loader should be shown.
- * @param emptyResultValue The value that represents no results. This will be emitted, and also deep-compared to with `isEqual()`. Example: `null`, `[]`
+ * @param loaderDelay The delay, in milliseconds, after which a loader should be shown if no results have been emitted.
+ * @param emptyResultValue The value that represents the absence of results. This will be emitted, and also deep-compared to with `isEqual()`. Example: `null`, `[]`
  *
  * @template TResult The type of the provider result (without `TEmpty`).
  * @template TEmpty The type of the empty value, e.g. `null` or `[]`.

--- a/src/loading.ts
+++ b/src/loading.ts
@@ -64,7 +64,7 @@ export const emitLoading = <TResult, TEmpty>(
             filter(([{ isLoading, result }]) => isLoading && isEqual(result, emptyResultValue)),
             mapTo(LOADING)
         ),
-        // Show the provider results (and no more loader) once the source emitted the first result
+        // Show the provider results (and no more loader) once the source emitted the first result or is no longer loading.
         sharedSource.pipe(
             filter(({ isLoading, result }) => !isLoading || !isEqual(result, emptyResultValue)),
             map(({ result }) => result)

--- a/src/loading.ts
+++ b/src/loading.ts
@@ -1,5 +1,5 @@
 import { OperatorFunction, merge, combineLatest, of } from 'rxjs'
-import { share, startWith, map, filter, mapTo, delay, endWith, scan } from 'rxjs/operators'
+import { share, startWith, map, filter, mapTo, delay, endWith, scan, takeUntil, last } from 'rxjs/operators'
 import { isEqual } from 'lodash'
 
 export const LOADING = 'loading' as const
@@ -58,7 +58,11 @@ export const emitLoading = <TResult, TEmpty>(
             ),
             // Make sure LOADER_DELAY has passed since this token has been hovered
             // (no matter if the source has emitted already)
-            of(null).pipe(delay(loaderDelay)),
+            of(null).pipe(
+                delay(loaderDelay),
+                // Stop and ignore the timer when the source Observable completes
+                takeUntil(sharedSource.pipe(last(null, null)))
+            ),
         ]).pipe(
             // Show the loader when the provider is loading and has no result yet
             filter(([{ isLoading, result }]) => isLoading && isEqual(result, emptyResultValue)),

--- a/src/loading.ts
+++ b/src/loading.ts
@@ -1,0 +1,73 @@
+import { OperatorFunction, merge, combineLatest, of } from 'rxjs'
+import { share, startWith, map, filter, mapTo, delay, endWith, scan } from 'rxjs/operators'
+import { isEqual } from 'lodash'
+
+export const LOADING = 'loading' as const
+
+/**
+ * An emission from a result provider.
+ *
+ * @template T The type of the result. Should typically include an empty value, or even an error type.
+ */
+export interface MaybeLoadingResult<T> {
+    /**
+     * Whether the result provider is currently getting a new result.
+     */
+    isLoading: boolean
+
+    /**
+     * The latest result.
+     */
+    result: T
+}
+
+/**
+ * Handles input of MaybeLoadingResult (which contains both results and loading states) and returns a sequence of clear
+ * instructions on when to show a loader, results or nothing.
+ *
+ * @param loaderDelay After how many milliseconds of no results a loader should be shown.
+ * @param emptyResultValue The value that represents no results. This will be emitted, and also deep-compared to with `isEqual()`. Example: `null`, `[]`
+ *
+ * @template TResult The type of the provider result (without `TEmpty`).
+ * @template TEmpty The type of the empty value, e.g. `null` or `[]`.
+ */
+export const emitLoading = <TResult, TEmpty>(
+    loaderDelay: number,
+    emptyResultValue: TEmpty
+): OperatorFunction<MaybeLoadingResult<TResult | TEmpty>, TResult | TEmpty | typeof LOADING | undefined> => source => {
+    const sharedSource = source.pipe(
+        // Prevent a loading indicator to be shown forever if the source completes without a result.
+        endWith<Partial<MaybeLoadingResult<TResult | TEmpty>>>({ isLoading: false }),
+        scan<Partial<MaybeLoadingResult<TResult | TEmpty>>, MaybeLoadingResult<TResult | TEmpty>>(
+            (previous, current) => ({ ...previous, ...current }),
+            { isLoading: true, result: emptyResultValue }
+        ),
+        share()
+    )
+    return merge(
+        // `undefined` is used here as opposed to `emptyResultValue` to distinguish between "no result" and the time
+        // between invocation and when a loader is shown.
+        // See for example "DEFERRED HOVER OVERLAY PINNING" in hoverifier.ts
+        [undefined],
+        // Show a loader if the provider is loading, has no result yet and hasn't emitted after LOADER_DELAY.
+        // combineLatest() is used here to block on the loader delay.
+        combineLatest([
+            sharedSource.pipe(
+                // Consider the provider loading initially.
+                startWith({ isLoading: true, result: emptyResultValue })
+            ),
+            // Make sure LOADER_DELAY has passed since this token has been hovered
+            // (no matter if the source has emitted already)
+            of(null).pipe(delay(loaderDelay)),
+        ]).pipe(
+            // Show the loader when the provider is loading and has no result yet
+            filter(([{ isLoading, result }]) => isLoading && isEqual(result, emptyResultValue)),
+            mapTo(LOADING)
+        ),
+        // Show the provider results (and no more loader) once the source emitted the first result
+        sharedSource.pipe(
+            filter(({ isLoading, result }) => !isLoading || !isEqual(result, emptyResultValue)),
+            map(({ result }) => result)
+        )
+    )
+}

--- a/src/testutils/fixtures.ts
+++ b/src/testutils/fixtures.ts
@@ -3,6 +3,7 @@ import { delay } from 'rxjs/operators'
 
 import { ActionsProvider, HoverProvider } from '../hoverifier'
 import { HoverAttachment } from '../types'
+import { MaybeLoadingResult } from '../loading'
 
 /**
  * Create a stubbed HoverAttachment object.
@@ -28,7 +29,10 @@ export function createStubHoverProvider(
     hover: Partial<HoverAttachment> = {},
     delayTime?: number
 ): HoverProvider<{}, {}> {
-    return () => of(createHoverAttachment(hover)).pipe(delay(delayTime ?? 0))
+    return () =>
+        of<MaybeLoadingResult<{}>>({ isLoading: false, result: createHoverAttachment(hover) }).pipe(
+            delay(delayTime ?? 0)
+        )
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,7 @@
 import { Position, Range } from '@sourcegraph/extension-api-types'
 import { ErrorLike } from './errors'
 import { HoveredToken } from './token_position'
-
-export const LOADING = 'loading' as const
+import { LOADING } from './loading'
 
 /**
  * @template C Extra context for the hovered token.
@@ -11,7 +10,7 @@ export const LOADING = 'loading' as const
  */
 export interface HoverOverlayProps<C extends object, D, A> {
     /** What to show as contents */
-    hoverOrError?: typeof LOADING | (HoverAttachment & D) | null | ErrorLike // TODO disallow null and undefined
+    hoverOrError?: typeof LOADING | (HoverAttachment & D) | null | ErrorLike
 
     /** The position of the tooltip (assigned to `style`) */
     overlayPosition?: { left: number; top: number }

--- a/webpack.test.config.ts
+++ b/webpack.test.config.ts
@@ -30,6 +30,7 @@ const config: Configuration = {
     },
     resolve: {
         extensions: ['.ts', '.js', '.html'],
+        mainFields: ['es2015', 'module', 'browser', 'main'],
     },
     output: {
         filename: '[name].js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,14 +57,6 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
   integrity sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
 
-"@babel/runtime-corejs2@^7.2.0":
-  version "7.4.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.4.2.tgz#a0cec2c41717fa415e9c204f32b603d88b1796c2"
-  integrity sha512-y/Br/9uQnumcqcakkmobFqOTzYCWSS6Kuy1b2o7LTXR4lpeU0AhaOcPqIHW85LCxRWUDW5Vg0pU1KlE3YkORlg==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.2"
-
 "@babel/runtime-corejs3@^7.8.3":
   version "7.9.2"
   resolved "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz#26fe4aa77e9f1ecef9b776559bbb8e84d34284b7"
@@ -2221,7 +2213,7 @@ core-js-pure@^3.0.0:
   resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
-core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5:
+core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
@@ -2807,7 +2799,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.5:
+es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.5, es-abstract@^1.5.1:
   version "1.17.5"
   resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz#d8c9d1d66c8981fb9200e2251d799eee92774ae9"
   integrity sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==
@@ -2823,27 +2815,6 @@ es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.5:
     object.assign "^4.1.0"
     string.prototype.trimleft "^2.1.1"
     string.prototype.trimright "^2.1.1"
-
-es-abstract@^1.5.1:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
-  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
-  dependencies:
-    es-to-primitive "^1.2.0"
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    is-callable "^1.1.4"
-    is-regex "^1.0.4"
-    object-keys "^1.0.12"
-
-es-to-primitive@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
-  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
-  dependencies:
-    is-callable "^1.1.4"
-    is-date-object "^1.0.1"
-    is-symbol "^1.0.2"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -3895,12 +3866,7 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
-  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
-
-has-symbols@^1.0.1:
+has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
@@ -3941,7 +3907,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1, has@^1.0.3:
+has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
@@ -4323,12 +4289,7 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-callable@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
-  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
-
-is-callable@^1.1.5:
+is-callable@^1.1.4, is-callable@^1.1.5:
   version "1.1.5"
   resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
   integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
@@ -4502,13 +4463,6 @@ is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
   integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
-
-is-regex@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
-  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
-  dependencies:
-    has "^1.0.1"
 
 is-regex@^1.0.5:
   version "1.0.5"
@@ -5680,15 +5634,10 @@ ms@2.1.1, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-mute-stream@0.0.8:
+mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
-
-mute-stream@~0.0.4:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
-  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
 nan@^2.12.1:
   version "2.14.0"
@@ -6169,12 +6118,7 @@ object-inspect@^1.7.0:
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
   integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
 
-object-keys@^1.0.11, object-keys@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
-  integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
-
-object-keys@^1.1.1:
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -7131,12 +7075,7 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
-  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
-
-regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.4:
   version "0.13.5"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
@@ -7366,17 +7305,10 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.3.2, rxjs@^6.5.3:
+rxjs@^6.3.2, rxjs@^6.5.3, rxjs@^6.5.5:
   version "6.5.5"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
   integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^6.3.3:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
-  integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
   dependencies:
     tslib "^1.9.0"
 
@@ -8385,14 +8317,7 @@ tsutils-etc@^1.0.0:
   resolved "https://registry.npmjs.org/tsutils-etc/-/tsutils-etc-1.2.2.tgz#cdeeb777574a5c1b15b27658cb8424f7f7139831"
   integrity sha512-5g2cXpD1OoVc/MLZxh5PuHXhlnYQmuRiW66e1n91j+2J/Pw5lfmVcZAghoDVBdltDXGaCjy8ZttXaX2u/MjHgg==
 
-tsutils@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.9.1.tgz#2a40dc742943c71eca6d5c1994fcf999956be387"
-  integrity sha512-hrxVtLtPqQr//p8/msPT1X1UYXUjizqSit5d9AQ5k38TcV38NyecL5xODNxa73cLe/5sdiJ+w1FqzDhRBA/anA==
-  dependencies:
-    tslib "^1.8.1"
-
-tsutils@^3.17.1:
+tsutils@^3.0.0, tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
   integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
@@ -8635,15 +8560,10 @@ uuid@^3.1.0, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-v8-compile-cache@2.0.3:
+v8-compile-cache@2.0.3, v8-compile-cache@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"
   integrity sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==
-
-v8-compile-cache@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
-  integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
 
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
@@ -8892,14 +8812,7 @@ xmlhttprequest-ssl@~1.5.4:
   resolved "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
 
-xregexp@^4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.2.4.tgz#02a4aea056d65a42632c02f0233eab8e4d7e57ed"
-  integrity sha512-sO0bYdYeJAJBcJA8g7MJJX7UrOZIfJPd8U2SC7B2Dd/J24U0aQNoGp33shCaBSWeb0rD5rh6VBUIXOkGal1TZA==
-  dependencies:
-    "@babel/runtime-corejs2" "^7.2.0"
-
-xregexp@^4.3.0:
+xregexp@^4.2.4, xregexp@^4.3.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz#7e92e73d9174a99a59743f67a4ce879a04b5ae50"
   integrity sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==


### PR DESCRIPTION
This addresses https://github.com/sourcegraph/sourcegraph/issues/9349, https://github.com/sourcegraph/sourcegraph/issues/9350 and https://github.com/sourcegraph/sourcegraph/issues/9346.

Codeintellify was originally not written to support providers updating the hover content later. It accepted Observables for cancellation, but they were intended to only emit once.

With extensions, Observables started to emit multiple times to update the content. The problem is that the period between invocation and the first result is used to display a loading indicator. But with multiple emissions, the situation can arise where first an empty result is emitted (e.g. because no providers were registered yet), then providers get registered and start loading, then emit actual non-empty result. Codeintellify had no way to know that providers started loading again.

This changes the types so that when an Observable is returned, it has to contain information about when the provider is loading or not loading in addition to the result to show (through `MaybeLoadingResult<T>`). It's still possible to only emit a single result by returning a Promise, in which case this information does not need to be provided because it is known (time between invocation and resolution).

This information is then used to make the loading indicator logic smarter - it now shows a loader even if the provider had emitted an empty result before, given that the LOADER_DELAY has elapsed. This logic was also duplicated with only slight modifications for definitions (in the main repo), so it is now abstracted in its own reusable Rx operator, which has Rx marble unit tests.

PR for the main repo: https://github.com/sourcegraph/sourcegraph/pull/9914