### PR TITLE
feat: document highlights

### DIFF
--- a/src/hoverifier.test.ts
+++ b/src/hoverifier.test.ts
@@ -360,14 +360,6 @@ describe('Hoverifier', () => {
                 findPositionsFromEvents({ domFunctions: codeViewProps })
             )
 
-            const codeViewSubscription = hoverifier.hoverify({
-                dom: codeViewProps,
-                positionEvents: NEVER,
-                positionJumps: NEVER,
-                resolveContext: () => {
-                    throw new Error('not called')
-                },
-            })
             hoverifier.hoverify({
                 dom: codeViewProps,
                 positionEvents,
@@ -387,11 +379,7 @@ describe('Hoverifier', () => {
                 )
                 .toPromise()
 
-            codeViewSubscription.unsubscribe()
-
-            assert.isDefined(hoverifier.hoverState.hoverOverlayProps)
             await of(null).pipe(delay(200)).toPromise()
-            assert.isDefined(hoverifier.hoverState.hoverOverlayProps)
 
             const selected = codeViewProps.codeView.querySelectorAll('.test-highlight')
             assert.equal(selected.length, 3)

--- a/src/hoverifier.test.ts
+++ b/src/hoverifier.test.ts
@@ -16,7 +16,12 @@ import {
 } from './hoverifier'
 import { findPositionsFromEvents, SupportedMouseEvent } from './positions'
 import { CodeViewProps, DOM } from './testutils/dom'
-import { createHoverAttachment, createStubActionsProvider, createStubHoverProvider } from './testutils/fixtures'
+import {
+    createHoverAttachment,
+    createStubActionsProvider,
+    createStubHoverProvider,
+    createStubDocumentHighlightProvider,
+} from './testutils/fixtures'
 import { dispatchMouseEventAtPositionImpure } from './testutils/mouse'
 import { HoverAttachment } from './types'
 import { LOADING } from './loading'
@@ -53,6 +58,7 @@ describe('Hoverifier', () => {
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider({ range: hoverRange }, LOADER_DELAY + delayTime),
+                    getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: () => of(null),
                     pinningEnabled: true,
                 })
@@ -115,6 +121,7 @@ describe('Hoverifier', () => {
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover, delayTime),
+                    getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: createStubActionsProvider(['foo', 'bar'], delayTime),
                     pinningEnabled: true,
                 })
@@ -204,6 +211,7 @@ describe('Hoverifier', () => {
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover, delayTime),
+                    getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: createStubActionsProvider(['foo', 'bar'], delayTime),
                     pinningEnabled: false,
                 })
@@ -284,6 +292,7 @@ describe('Hoverifier', () => {
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover, delayTime),
+                    getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: createStubActionsProvider(['foo', 'bar'], delayTime),
                     pinningEnabled: false,
                 })
@@ -342,6 +351,7 @@ describe('Hoverifier', () => {
                     end: { line: 4, character: 9 },
                 },
             }),
+            getDocumentHighlights: createStubDocumentHighlightProvider(),
             getActions: createStubActionsProvider(['foo', 'bar']),
             pinningEnabled: true,
         })
@@ -396,6 +406,7 @@ describe('Hoverifier', () => {
                             position.line === 24
                                 ? createStubHoverProvider({}, delayTime)(position)
                                 : of({ isLoading: false, result: null }),
+                        getDocumentHighlights: createStubDocumentHighlightProvider(),
                         getActions: position =>
                             position.line === 24
                                 ? createStubActionsProvider(['foo', 'bar'], delayTime)(position)
@@ -473,6 +484,7 @@ describe('Hoverifier', () => {
                             position.line === 24
                                 ? createStubHoverProvider({})(position)
                                 : of({ isLoading: false, result: null }),
+                        getDocumentHighlights: createStubDocumentHighlightProvider(),
                         getActions: position =>
                             position.line === 24 ? createStubActionsProvider(['foo', 'bar'])(position) : of(null),
                         pinningEnabled: true,
@@ -555,6 +567,7 @@ describe('Hoverifier', () => {
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover, LOADER_DELAY + hoverDelayTime),
+                    getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: createStubActionsProvider(actions, LOADER_DELAY + actionsDelayTime),
                     pinningEnabled: true,
                 })
@@ -627,6 +640,7 @@ describe('Hoverifier', () => {
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover),
+                    getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: () => of(null),
                     pinningEnabled: true,
                 })
@@ -689,6 +703,7 @@ describe('Hoverifier', () => {
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover),
+                    getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: () => of(null),
                     pinningEnabled: true,
                 })
@@ -762,6 +777,7 @@ describe('Hoverifier', () => {
                 const adjustmentDirections = new Subject<AdjustmentDirection>()
 
                 const getHover = createStubHoverProvider({})
+                const getDocumentHighlights = createStubDocumentHighlightProvider()
                 const getActions = createStubActionsProvider(['foo', 'bar'])
 
                 const adjustPosition: PositionAdjuster<{}> = ({ direction, position }) => {
@@ -775,6 +791,7 @@ describe('Hoverifier', () => {
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover,
+                    getDocumentHighlights,
                     getActions,
                     pinningEnabled: true,
                 })
@@ -831,6 +848,7 @@ describe('Hoverifier', () => {
                     hoverOverlayRerenders: EMPTY,
                     // It's important that getHover() and getActions() emit something
                     getHover: createStubHoverProvider({}),
+                    getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: () => of([{}]).pipe(delay(50)),
                     pinningEnabled: true,
                 })
@@ -870,6 +888,7 @@ describe('Hoverifier', () => {
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(),
+                    getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: () => of(null),
                     pinningEnabled: true,
                 })

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -844,7 +844,7 @@ export function createHoverifier<C extends object, D, A>({
         codeView: HTMLElement
         codeViewId: symbol
         scrollBoundaries?: HTMLElement[]
-        documentHighlightsOrError?: DocumentHighlight[] | ErrorLike
+        documentHighlightsOrError?: DocumentHighlight[]
         position?: HoveredToken & C
         part?: DiffPart
     }>> = resolvedPositions.pipe(
@@ -860,7 +860,10 @@ export function createHoverifier<C extends object, D, A>({
             }
             // Get the document highlights for that position
             return from(getDocumentHighlights(position)).pipe(
-                catchError((error): [ErrorLike] => [asError(error)]),
+                catchError(error => {
+                    console.error(error)
+                    return []
+                }),
                 map(documentHighlightsOrError => ({
                     ...rest,
                     codeViewId,

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -50,8 +50,8 @@ import { emitLoading, MaybeLoadingResult, LOADING } from './loading'
 
 export { HoveredToken }
 
-const selectionHighlightClassName = 'selection-highlight'
-const documentHighlightClassName = 'sourcegraph-document-highlight'
+const defaultSelectionHighlightClassName = 'selection-highlight'
+const defaultDocumentHighlightClassName = 'sourcegraph-document-highlight'
 
 /**
  * @template C Extra context for the hovered token.
@@ -105,6 +105,16 @@ export interface HoverifierOptions<C extends object, D, A> {
      * Whether or not code views need to be tokenized. Defaults to true.
      */
     tokenize?: boolean
+
+    /**
+     * The class name to apply to hovered tokens.
+     */
+    selectionHighlightClassName?: string
+
+    /**
+     * The class name to apply to document highlight tokens.
+     */
+    documentHighlightClassName?: string
 }
 
 /**
@@ -394,6 +404,8 @@ export function createHoverifier<C extends object, D, A>({
     getActions,
     pinningEnabled,
     tokenize = true,
+    selectionHighlightClassName = defaultSelectionHighlightClassName,
+    documentHighlightClassName = defaultDocumentHighlightClassName,
 }: HoverifierOptions<C, D, A>): Hoverifier<C, D, A> {
     // Internal state that is not exposed to the caller
     // Shared between all hoverified code views

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -739,7 +739,6 @@ export function createHoverifier<C extends object, D, A>({
             if (!position) {
                 return of({ hoverOrError: null, position: undefined, part: undefined, codeViewId, ...rest })
             }
-
             // Get the hover for that position
             return toMaybeLoadingProviderResult(getHover(position)).pipe(
                 catchError((error): [MaybeLoadingResult<ErrorLike>] => [{ isLoading: false, result: asError(error) }]),

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -365,7 +365,7 @@ export type HoverProvider<C extends object, D> = (
  */
 export type DocumentHighlightProvider<C extends object> = (
     position: HoveredToken & C
-) => Subscribable<DocumentHighlight[] | null> | PromiseLike<DocumentHighlight[] | null>
+) => Subscribable<DocumentHighlight[]> | PromiseLike<DocumentHighlight[]>
 
 /**
  * @template C Extra context for the hovered token.
@@ -844,14 +844,14 @@ export function createHoverifier<C extends object, D, A>({
         codeView: HTMLElement
         codeViewId: symbol
         scrollBoundaries?: HTMLElement[]
-        documentHighlightsOrError?: DocumentHighlight[] | ErrorLike | null
+        documentHighlightsOrError?: DocumentHighlight[] | ErrorLike
         position?: HoveredToken & C
         part?: DiffPart
     }>> = resolvedPositions.pipe(
         map(({ position, codeViewId, ...rest }) => {
             if (!position) {
                 return of({
-                    documentHighlightsOrError: null,
+                    documentHighlightsOrError: [],
                     position: undefined,
                     part: undefined,
                     codeViewId,

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -50,6 +50,9 @@ import { emitLoading, MaybeLoadingResult, LOADING } from './loading'
 
 export { HoveredToken }
 
+const selectionHighlightClass = 'selection-highlight'
+const documentHighlightClass = 'sourcegraph-document-highlight'
+
 /**
  * @template C Extra context for the hovered token.
  * @template D The type of the hover content data.
@@ -820,12 +823,12 @@ export function createHoverifier<C extends object, D, A>({
                 })
                 // Ensure the previously highlighted range is not highlighted and the new highlightedRange (if any)
                 // is highlighted.
-                const currentHighlighted = codeView.querySelector('.selection-highlight')
+                const currentHighlighted = codeView.querySelector(`.${selectionHighlightClass}`)
                 if (currentHighlighted) {
-                    currentHighlighted.classList.remove('selection-highlight')
+                    currentHighlighted.classList.remove(selectionHighlightClass)
                 }
                 if (hoveredTokenElement) {
-                    hoveredTokenElement.classList.add('selection-highlight')
+                    hoveredTokenElement.classList.add(selectionHighlightClass)
                 }
             })
     )
@@ -939,14 +942,14 @@ export function createHoverifier<C extends object, D, A>({
             .subscribe(({ codeView, elements }) => {
                 // Ensure the previously highlighted range is not highlighted and the new highlightedRange (if any)
                 // is highlighted.
-                const currentHighlighteds = codeView.querySelectorAll('.document-highlight')
+                const currentHighlighteds = codeView.querySelectorAll(`.${documentHighlightClass}`)
                 for (const currentHighlighted of currentHighlighteds) {
-                    currentHighlighted.classList.remove('document-highlight')
+                    currentHighlighted.classList.remove(documentHighlightClass)
                 }
 
                 for (const element of elements) {
                     if (element) {
-                        element.classList.add('document-highlight')
+                        element.classList.add(documentHighlightClass)
                     }
                 }
             })

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -898,8 +898,13 @@ export function createHoverifier<C extends object, D, A>({
                         codeView,
                         part,
                         ...rest,
-                        // Adjust the position of each highlight range so that it can be resolved
-                        // to a token in the current document in the next step.
+                        // Adjust the position of each highlight range so that it can be resolved to a
+                        // token in the current document in the next step. This currently on highlights the
+                        // token that intersects with the start of the highlight range, but this is all we
+                        // need in the majority of cases as we currently only highlight references.
+                        //
+                        // To expand this use case in the future, we should determine all intersecting tokens
+                        // between the range start and end positions.
                         positions: combineLatest(
                             highlights.map(({ range }) => {
                                 let pos = { ...position, ...range.start }
@@ -928,9 +933,7 @@ export function createHoverifier<C extends object, D, A>({
                     positions.pipe(
                         map(highlightedRanges =>
                             highlightedRanges.map(highlightedRange =>
-                                highlightedRange
-                                    ? getTokenAtPosition(codeView, highlightedRange, dom, part, tokenize)
-                                    : undefined
+                                getTokenAtPosition(codeView, highlightedRange, dom, part, tokenize)
                             )
                         ),
                         map(elements => ({ elements, codeView, dom, part }))

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -948,8 +948,8 @@ export function createHoverifier<C extends object, D, A>({
             .subscribe(({ codeView, elements }) => {
                 // Ensure the previously highlighted range is not highlighted and the new highlightedRange (if any)
                 // is highlighted.
-                const currentHighlighteds = codeView.querySelectorAll(`.${documentHighlightClassName}`)
-                for (const currentHighlighted of currentHighlighteds) {
+                const currentHighlights = codeView.querySelectorAll(`.${documentHighlightClassName}`)
+                for (const currentHighlighted of currentHighlights) {
                     currentHighlighted.classList.remove(documentHighlightClassName)
                 }
 

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -50,8 +50,8 @@ import { emitLoading, MaybeLoadingResult, LOADING } from './loading'
 
 export { HoveredToken }
 
-const selectionHighlightClass = 'selection-highlight'
-const documentHighlightClass = 'sourcegraph-document-highlight'
+const selectionHighlightClassName = 'selection-highlight'
+const documentHighlightClassName = 'sourcegraph-document-highlight'
 
 /**
  * @template C Extra context for the hovered token.
@@ -823,12 +823,12 @@ export function createHoverifier<C extends object, D, A>({
                 })
                 // Ensure the previously highlighted range is not highlighted and the new highlightedRange (if any)
                 // is highlighted.
-                const currentHighlighted = codeView.querySelector(`.${selectionHighlightClass}`)
+                const currentHighlighted = codeView.querySelector(`.${selectionHighlightClassName}`)
                 if (currentHighlighted) {
-                    currentHighlighted.classList.remove(selectionHighlightClass)
+                    currentHighlighted.classList.remove(selectionHighlightClassName)
                 }
                 if (hoveredTokenElement) {
-                    hoveredTokenElement.classList.add(selectionHighlightClass)
+                    hoveredTokenElement.classList.add(selectionHighlightClassName)
                 }
             })
     )
@@ -942,14 +942,14 @@ export function createHoverifier<C extends object, D, A>({
             .subscribe(({ codeView, elements }) => {
                 // Ensure the previously highlighted range is not highlighted and the new highlightedRange (if any)
                 // is highlighted.
-                const currentHighlighteds = codeView.querySelectorAll(`.${documentHighlightClass}`)
+                const currentHighlighteds = codeView.querySelectorAll(`.${documentHighlightClassName}`)
                 for (const currentHighlighted of currentHighlighteds) {
-                    currentHighlighted.classList.remove(documentHighlightClass)
+                    currentHighlighted.classList.remove(documentHighlightClassName)
                 }
 
                 for (const element of elements) {
                     if (element) {
-                        element.classList.add(documentHighlightClass)
+                        element.classList.add(documentHighlightClassName)
                     }
                 }
             })

--- a/src/testutils/fixtures.ts
+++ b/src/testutils/fixtures.ts
@@ -1,8 +1,8 @@
 import { of } from 'rxjs'
 import { delay } from 'rxjs/operators'
 
-import { ActionsProvider, HoverProvider } from '../hoverifier'
-import { HoverAttachment } from '../types'
+import { ActionsProvider, HoverProvider, DocumentHighlightProvider } from '../hoverifier'
+import { HoverAttachment, DocumentHighlight } from '../types'
 import { MaybeLoadingResult } from '../loading'
 
 /**
@@ -13,6 +13,20 @@ import { MaybeLoadingResult } from '../loading'
 export const createHoverAttachment = (hover: Partial<HoverAttachment> = {}): HoverAttachment => ({
     range: hover.range
         ? hover.range
+        : {
+              start: { line: 24, character: 10 },
+              end: { line: 24, character: 14 },
+          },
+})
+
+/**
+ * Create a stubbed DocumentHighlight object.
+ *
+ * @param documentHighlight optional values for the DocumentHighlight object. If none is provided, we'll output defaults.
+ */
+export const createDocumentHighlight = (documentHighlight: Partial<DocumentHighlight> = {}): DocumentHighlight => ({
+    range: documentHighlight.range
+        ? documentHighlight.range
         : {
               start: { line: 24, character: 10 },
               end: { line: 24, character: 14 },
@@ -33,6 +47,23 @@ export function createStubHoverProvider(
         of<MaybeLoadingResult<{}>>({ isLoading: false, result: createHoverAttachment(hover) }).pipe(
             delay(delayTime ?? 0)
         )
+}
+
+/**
+ * Create a stubbed DocumentHighlightProvider
+ *
+ * @param documentHighlights optional values to be passed to createDocumentHighlight
+ * @param delayTime optionally delay the document highlight fetch
+ */
+export function createStubDocumentHighlightProvider(
+    documentHighlights: Partial<DocumentHighlight>[] = [],
+    delayTime?: number
+): DocumentHighlightProvider<{}> {
+    return () =>
+        of<MaybeLoadingResult<DocumentHighlight[]>>({
+            isLoading: false,
+            result: documentHighlights.map(createDocumentHighlight),
+        }).pipe(delay(delayTime ?? 0))
 }
 
 /**

--- a/src/testutils/fixtures.ts
+++ b/src/testutils/fixtures.ts
@@ -59,11 +59,7 @@ export function createStubDocumentHighlightProvider(
     documentHighlights: Partial<DocumentHighlight>[] = [],
     delayTime?: number
 ): DocumentHighlightProvider<{}> {
-    return () =>
-        of<MaybeLoadingResult<DocumentHighlight[]>>({
-            isLoading: false,
-            result: documentHighlights.map(createDocumentHighlight),
-        }).pipe(delay(delayTime ?? 0))
+    return () => of<DocumentHighlight[]>(documentHighlights.map(createDocumentHighlight)).pipe(delay(delayTime ?? 0))
 }
 
 /**

--- a/src/testutils/fixtures.ts
+++ b/src/testutils/fixtures.ts
@@ -25,9 +25,8 @@ export const createHoverAttachment = (hover: Partial<HoverAttachment> = {}): Hov
  * @param documentHighlight optional values for the DocumentHighlight object. If none is provided, we'll output defaults.
  */
 export const createDocumentHighlight = (documentHighlight: Partial<DocumentHighlight> = {}): DocumentHighlight => ({
-    range: documentHighlight.range
-        ? documentHighlight.range
-        : {
+    range: documentHighlight.range ??
+        {
               start: { line: 24, character: 10 },
               end: { line: 24, character: 14 },
           },

--- a/src/testutils/fixtures.ts
+++ b/src/testutils/fixtures.ts
@@ -25,11 +25,10 @@ export const createHoverAttachment = (hover: Partial<HoverAttachment> = {}): Hov
  * @param documentHighlight optional values for the DocumentHighlight object. If none is provided, we'll output defaults.
  */
 export const createDocumentHighlight = (documentHighlight: Partial<DocumentHighlight> = {}): DocumentHighlight => ({
-    range: documentHighlight.range ??
-        {
-              start: { line: 24, character: 10 },
-              end: { line: 24, character: 14 },
-          },
+    range: documentHighlight.range ?? {
+        start: { line: 24, character: 10 },
+        end: { line: 24, character: 14 },
+    },
 })
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,11 +42,11 @@ export interface HoverAttachment {
 }
 
 /**
- * TODO - document
+ * Describes a range in the document that should be highlighted.
  */
 export interface DocumentHighlight {
     /**
-     * TODO - document
+     * The range to be highlighted.
      */
     range: Range
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,16 @@ export interface HoverAttachment {
 }
 
 /**
+ * TODO - document
+ */
+export interface DocumentHighlight {
+    /**
+     * TODO - document
+     */
+    range: Range
+}
+
+/**
  * Reports whether {@link value} is a {@link Position}.
  */
 export function isPosition(value: any): value is Position {


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/10868. Sibling PRs: https://github.com/sourcegraph/sourcegraph/pull/11822 and https://github.com/sourcegraph/code-intel-extensions/pull/409

This PR adds functionality to subscribe to hover events and highlight the ranges which are returned from the new `createHoverifier` parameter of `createHoverifier`. This is conceptually symmetric to what happens when the hover symbol itself is highlighted.

![Kapture 2020-07-01 at 10 03 05](https://user-images.githubusercontent.com/103087/86259887-33f41c00-bb82-11ea-99b8-ab3c08608aaf.gif)
