### PR TITLE
Fix off-by-one highlighting error

### DIFF
--- a/src/hoverifier.test.ts
+++ b/src/hoverifier.test.ts
@@ -50,7 +50,7 @@ describe('Hoverifier', () => {
 
             const delayTime = 100
             const hoverRange = { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } }
-            const hoverRange1Indexed = { start: { line: 2, character: 3 }, end: { line: 4, character: 5 } }
+            const hoverRange1Indexed = { start: { line: 2, character: 3 }, end: { line: 4, character: 4 } }
 
             scheduler.run(({ cold, expectObservable }) => {
                 const hoverifier = createHoverifier({

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -667,8 +667,8 @@ export function createHoverifier<C extends object, D, A>({
      *
      * Returns `undefined` if the hover result is not successful.
      *
-     * Uses the range specified by the hover result if present, or `position` oherwise,
-     * which will be expanded into a full token in getTokenAtPosition().
+     * Uses the range specified by the hover result if present, or `position` otherwise,
+     * which will be expanded into a full token in getTokenAtPositionOrRange().
      */
     const getHighlightedRange = ({
         hoverOrError,

--- a/src/hoverifier.ts
+++ b/src/hoverifier.ts
@@ -687,7 +687,7 @@ export function createHoverifier<C extends object, D, A>({
                     },
                     end: {
                         line: hoverOrError.range.end.line + 1,
-                        character: hoverOrError.range.end.character + 1,
+                        character: hoverOrError.range.end.character,
                     },
                 }
             }


### PR DESCRIPTION
This PR fixes an off-by-one highlighting issue for all LSIF-based that was introduced (and has been present since) https://github.com/sourcegraph/codeintellify/pull/331.

This fixes the behavior for me when run locally, but I'm going to delegate an _actual_ solution to @tjkandala as there may be a better or more general solution to what's here. I'm not 100% I understand my change or a lot of the related code here. There's likely a better solution farther up or farther down the call stack, but this _seems_ to work for a very specific use case during manual testing.

The recent merge of https://github.com/sourcegraph/code-intel-extensions/pull/594 should make this problem (and subsequent fix) more apparent. We were not always returning the range data from the code intel extension. Note that we always return zero-indexed and half-closed intervals for ranges (as stated by the LSP spec).

Note that the highlighting is correct for document highlights, so this bug seems to only exist when displaying the ranges given back by the hover observable. The other observable behavior seem correct.

<img width="636" alt="Screen Shot 2021-03-31 at 5 24 43 PM" src="https://user-images.githubusercontent.com/103087/113231485-f4697600-9260-11eb-904d-d46ba89aca9a.png">
<img width="949" alt="Screen Shot 2021-03-31 at 11 30 43 AM" src="https://user-images.githubusercontent.com/103087/113231488-f5020c80-9260-11eb-93b5-7ac384b2e18f.png">
<img width="820" alt="Screen Shot 2021-03-31 at 11 32 18 AM" src="https://user-images.githubusercontent.com/103087/113231489-f5020c80-9260-11eb-9574-7f9fdd32e686.png">
<img width="1035" alt="Screen Shot 2021-03-31 at 11 34 26 AM" src="https://user-images.githubusercontent.com/103087/113231491-f59aa300-9260-11eb-8336-c5aeaaa4ad9d.png">
<img width="1030" alt="Screen Shot 2021-03-31 at 11 35 00 AM" src="https://user-images.githubusercontent.com/103087/113231494-f6333980-9260-11eb-8e73-28bc84b5ae65.png">
