### PR TITLE
fix: exclude end position in findElementWithOffset

### DIFF
--- a/src/token_position.test.ts
+++ b/src/token_position.test.ts
@@ -180,13 +180,13 @@ describe('token_positions', () => {
                 const content = `${tabChar}if rv := contextGet(r, routeKey); rv != nil {`
 
                 const ranges = [
-                    { offsetStart: 2, offsetEnd: 3, textContent: 'if' },
+                    { offsetStart: 2, offsetEnd: 4, textContent: 'if' },
+                    { offsetStart: 2, offsetEnd: 5, textContent: 'if ' },
                     // Intentional limitation: match whole text node at a given offset
                     // since that is much simpler to highlight.
-                    { offsetStart: 3, offsetEnd: 5, textContent: 'if rv' },
-                    { offsetStart: 2, offsetEnd: 5, textContent: 'if rv' },
+                    { offsetStart: 3, offsetEnd: 5, textContent: 'if ' },
                     { offsetStart: 2, offsetEnd: 6, textContent: 'if rv' },
-                    { offsetStart: 11, offsetEnd: 33, textContent: 'contextGet(r, routeKey)' },
+                    { offsetStart: 11, offsetEnd: 34, textContent: 'contextGet(r, routeKey)' },
                     // If offsetEnd is less or equal to offsetStart, range should be treated as a position (offsetStart)
                     { offsetStart: 11, offsetEnd: 4, textContent: 'contextGet' },
                 ]
@@ -244,7 +244,7 @@ describe('token_positions', () => {
 
                 const offsets = [
                     { offsetStart: content.length + 1, offsetEnd: content.length + 2 },
-                    { offsetStart: 1, offsetEnd: content.length + 1 },
+                    { offsetStart: 1, offsetEnd: content.length + 2 },
                 ]
 
                 const elem = dom.createElementFromString(content)

--- a/src/token_position.ts
+++ b/src/token_position.ts
@@ -289,7 +289,8 @@ export function findElementWithOffset(
             }
             // offsetEnd should be greater than offsetStart, so only check for it after targetStartNode has been found
             if (targetStartNode) {
-                if (offsetStep <= offsetEnd && offsetStep + text.length > offsetEnd) {
+                // End position of range is exclusive
+                if (offsetStep < offsetEnd && offsetStep + text.length >= offsetEnd) {
                     targetEndNode = node
                     break
                 }


### PR DESCRIPTION
Fix error discussed in #360, introduced by #331.

Treat end position of a range as exclusive. Previously, we would erroneously highlight DOM nodes that started at hovered nodes' specified end positions.