### PR TITLE
feat: add code view-specific tokenization settings

### DIFF
--- a/src/token_position.ts
+++ b/src/token_position.ts
@@ -66,6 +66,19 @@ export function convertCodeElementIdempotent(element: HTMLElement): void {
 }
 
 /**
+ * Helper function to determine whether the code view should be tokenized.
+ */
+export function shouldTokenize({
+    tokenize,
+    overrideTokenize,
+}: {
+    tokenize: boolean
+    overrideTokenize: boolean | undefined
+}): boolean {
+    return typeof overrideTokenize === 'boolean' ? overrideTokenize : tokenize
+}
+
+/**
  * convertNode modifies a DOM node so that we can identify precisely token a user has clicked or hovered over.
  * On a code view, source code is typically wrapped in a HTML table cell. It may look like this:
  *


### PR DESCRIPTION
Some code hosts use many types of code views, some of which are tokenized and some of which are not. This PR introduces a way for consumers to override the `Hoverifier` instance `tokenize` flag through event options in `Hoverifer#hoverify`.